### PR TITLE
CPLAT-13185 Fix JsBackedMap for Dart 2.12

### DIFF
--- a/lib/react_client/js_backed_map.dart
+++ b/lib/react_client/js_backed_map.dart
@@ -58,12 +58,12 @@ class JsBackedMap extends MapBase<dynamic, dynamic> {
 
   @override
   dynamic operator [](Object key) {
-    return js_util.getProperty(jsObject, key);
+    return _JsBackedMapValue.unwrapIfNeeded(js_util.getProperty(jsObject, key));
   }
 
   @override
   void operator []=(dynamic key, dynamic value) {
-    js_util.setProperty(jsObject, key, value);
+    js_util.setProperty(jsObject, key, _JsBackedMapValue.wrapIfNeeded(value));
   }
 
   @override
@@ -122,6 +122,28 @@ class JsBackedMap extends MapBase<dynamic, dynamic> {
     // hashCode collisions more often, they are completely valid.
     // For more information, see the `Object.hashCode` doc comment.
     return 0;
+  }
+}
+
+/// A wrapper around a value that can't be stored in its raw form
+/// within a JS object (e.g., a Dart function).
+class _JsBackedMapValue {
+  final dynamic value;
+
+  const _JsBackedMapValue(this.value);
+
+  static dynamic wrapIfNeeded(dynamic value) {
+    if (value is Function && !identical(allowInterop(value), value)) {
+      return _JsBackedMapValue(value);
+    }
+    return value;
+  }
+
+  static dynamic unwrapIfNeeded(dynamic value) {
+    if (value is _JsBackedMapValue) {
+      return value.value;
+    }
+    return value;
   }
 }
 

--- a/lib/react_client/js_backed_map.dart
+++ b/lib/react_client/js_backed_map.dart
@@ -6,6 +6,7 @@ import 'dart:core';
 import 'dart:js_util' as js_util;
 
 import 'package:js/js.dart';
+import 'package:react/src/react_client/private_utils.dart';
 
 /// A view into a JavaScript object ([jsObject]) that conforms to the Dart [Map] interface.
 ///
@@ -58,12 +59,12 @@ class JsBackedMap extends MapBase<dynamic, dynamic> {
 
   @override
   dynamic operator [](Object key) {
-    return _JsBackedMapValue.unwrapIfNeeded(js_util.getProperty(jsObject, key));
+    return DartValueWrapper.unwrapIfNeeded(js_util.getProperty(jsObject, key));
   }
 
   @override
   void operator []=(dynamic key, dynamic value) {
-    js_util.setProperty(jsObject, key, _JsBackedMapValue.wrapIfNeeded(value));
+    js_util.setProperty(jsObject, key, DartValueWrapper.wrapIfNeeded(value));
   }
 
   @override
@@ -122,28 +123,6 @@ class JsBackedMap extends MapBase<dynamic, dynamic> {
     // hashCode collisions more often, they are completely valid.
     // For more information, see the `Object.hashCode` doc comment.
     return 0;
-  }
-}
-
-/// A wrapper around a value that can't be stored in its raw form
-/// within a JS object (e.g., a Dart function).
-class _JsBackedMapValue {
-  final dynamic value;
-
-  const _JsBackedMapValue(this.value);
-
-  static dynamic wrapIfNeeded(dynamic value) {
-    if (value is Function && !identical(allowInterop(value), value)) {
-      return _JsBackedMapValue(value);
-    }
-    return value;
-  }
-
-  static dynamic unwrapIfNeeded(dynamic value) {
-    if (value is _JsBackedMapValue) {
-      return value.value;
-    }
-    return value;
   }
 }
 

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -131,7 +131,7 @@ abstract class ContextHelpers {
   // It is wrapped so that the same Dart value can be retrieved from Dart with [_unjsifyNewContext].
   static dynamic jsifyNewContext(dynamic context) {
     var jsContextHolder = newObject();
-    setProperty(jsContextHolder, _reactDartContextSymbol, context);
+    setProperty(jsContextHolder, _reactDartContextSymbol, _ContextValue.wrapIfNeeded(context));
     return jsContextHolder;
   }
 
@@ -140,8 +140,30 @@ abstract class ContextHelpers {
   // when used with [_jsifyNewContext].
   static dynamic unjsifyNewContext(dynamic interopContext) {
     if (interopContext != null && hasProperty(interopContext, _reactDartContextSymbol)) {
-      return getProperty(interopContext, _reactDartContextSymbol);
+      return _ContextValue.unwrapIfNeeded(getProperty(interopContext, _reactDartContextSymbol));
     }
     return interopContext;
+  }
+}
+
+/// A wrapper around a value that can't be stored in its raw form
+/// within a JS object (e.g., a Dart function).
+class _ContextValue {
+  final dynamic value;
+
+  const _ContextValue(this.value);
+
+  static dynamic wrapIfNeeded(dynamic value) {
+    if (value is Function && !identical(allowInterop(value), value)) {
+      return _ContextValue(value);
+    }
+    return value;
+  }
+
+  static dynamic unwrapIfNeeded(dynamic value) {
+    if (value is _ContextValue) {
+      return value.value;
+    }
+    return value;
   }
 }

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -9,6 +9,7 @@ import 'dart:js_util';
 import 'package:js/js.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_client/component_factory.dart' show ReactJsContextComponentFactoryProxy;
+import 'package:react/src/react_client/private_utils.dart';
 
 /// The return type of [createContext], Wraps [ReactContext] for use in Dart.
 /// Allows access to [Provider] and [Consumer] Components.
@@ -131,7 +132,7 @@ abstract class ContextHelpers {
   // It is wrapped so that the same Dart value can be retrieved from Dart with [_unjsifyNewContext].
   static dynamic jsifyNewContext(dynamic context) {
     var jsContextHolder = newObject();
-    setProperty(jsContextHolder, _reactDartContextSymbol, _ContextValue.wrapIfNeeded(context));
+    setProperty(jsContextHolder, _reactDartContextSymbol, DartValueWrapper.wrapIfNeeded(context));
     return jsContextHolder;
   }
 
@@ -140,30 +141,8 @@ abstract class ContextHelpers {
   // when used with [_jsifyNewContext].
   static dynamic unjsifyNewContext(dynamic interopContext) {
     if (interopContext != null && hasProperty(interopContext, _reactDartContextSymbol)) {
-      return _ContextValue.unwrapIfNeeded(getProperty(interopContext, _reactDartContextSymbol));
+      return DartValueWrapper.unwrapIfNeeded(getProperty(interopContext, _reactDartContextSymbol));
     }
     return interopContext;
-  }
-}
-
-/// A wrapper around a value that can't be stored in its raw form
-/// within a JS object (e.g., a Dart function).
-class _ContextValue {
-  final dynamic value;
-
-  const _ContextValue(this.value);
-
-  static dynamic wrapIfNeeded(dynamic value) {
-    if (value is Function && !identical(allowInterop(value), value)) {
-      return _ContextValue(value);
-    }
-    return value;
-  }
-
-  static dynamic unwrapIfNeeded(dynamic value) {
-    if (value is _ContextValue) {
-      return value.value;
-    }
-    return value;
   }
 }

--- a/lib/src/react_client/private_utils.dart
+++ b/lib/src/react_client/private_utils.dart
@@ -59,3 +59,25 @@ void validateJsApi() {
     throw new Exception('Loaded react.js must include react-dart JS interop helpers.');
   }
 }
+
+/// A wrapper around a value that can't be stored in its raw form
+/// within a JS object (e.g., a Dart function).
+class DartValueWrapper {
+  final dynamic value;
+
+  const DartValueWrapper(this.value);
+
+  static dynamic wrapIfNeeded(dynamic value) {
+    if (value is Function && !identical(allowInterop(value), value)) {
+      return DartValueWrapper(value);
+    }
+    return value;
+  }
+
+  static dynamic unwrapIfNeeded(dynamic value) {
+    if (value is DartValueWrapper) {
+      return value.value;
+    }
+    return value;
+  }
+}


### PR DESCRIPTION
## Motivation

Dart 2.12 includes changes to `setProperty` that disallow passing in Dart functions, since they are not callable by JS code. https://github.com/dart-lang/sdk/commit/d683f33f5bfefe92ea1a590a800c7e41b213f69c

This breaks passing function props to Dart components, since `JsBackedMap` stores those values using `setProperty` under the hood.

```
  Assertion failed: org-dartlang-sdk:///lib/_internal/js_dev_runtime/private/ddc_runtime/types.dart:166:7
  _isJsObject(f) ||
            !JS<bool>('bool', '# instanceof #.Function', f, global_)
  "Dart function requires `allowInterop` to be passed to JavaScript."
  dart:sdk_internal                                        setProperty
  package:react/react_client/js_backed_map.dart 66:5       _set
  dart:sdk_internal                                        addAll
  package:react/react_client/js_backed_map.dart 96:13      addAll
  package:react/react_client/js_backed_map.dart 34:61      <fn>
  package:react/react_client/js_backed_map.dart 34:73      from
  package:react/src/react_client/factory_util.dart 167:34  generateJsProps
  package:react/react_client/component_factory.dart 86:7   generateExtendedJsProps
```

This is the reason that react-dart dev builds are currently failing.

We can work around this issue by wrapping Dart functions in an object, which can be passed through without issue.
- This shouldn't affect behavior
  - On the JS side, since JS code should already be treating Dart functions as non-callable, and any functions meant to be called by the JS are properly converted first
  - On the Dart side, since nothing accesses the raw JS values in the first place

## Changes 

- Added workaround based on Greg's  __Partial implementaion:__ https://github.com/Workiva/react-dart/pull/298/commits/371f5f7735d8475daafff988826cc9e4aa6c6889 
  - Applied the same workaround from `JsBackedMap` to `ContextHelpers`
- [Tests already cover both allowInterop-wrapped and non-allowInterop-wrapped functions](https://github.com/Workiva/react-dart/blob/master/test/shared_type_tester.dart#L66-L79) in `JsBackedMap` and context tests
- Ensure Dart dev channel builds are passing
- Perform consumer testing in over_react, WSD, and major Wdesk repos (DPC, graph_app, home)
  - Since these change affects such a core part of React interop, we want to make sure we're confident it won't cause regressions

## QA Steps

- [x] CI passes (including dev channel builds)
- [x] Verify tests adequately cover allowInterop-wrapped and non-allowInterop-wrapped functions (see [shared_type_tester.dart](https://github.com/Workiva/react-dart/blob/master/test/shared_type_tester.dart#L66-L79))
- [x] Verify that consumer tests are passing in:
  - [x] [over_react](https://github.com/Workiva/over_react/pull/683) (except dev channels because of NNBD)
  - [x] [web_skin_dart](https://github.com/Workiva/web_skin_dart/pull/1558)
  - [x] [doc_plat_client](https://github.com/Workiva/doc_plat_client/pull/13722)
  - [x] [cerebral-ui](https://github.com/Workiva/cerebral-ui/pull/1681)
  - [x] [graph_app](https://github.com/Workiva/graph_app/pull/17299)
  - [x] [home](https://github.com/Workiva/home/pull/4854)