### PR TITLE
RM-93289 Release react 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [6.0.1](https://github.com/cleandart/react-dart/compare/6.0.0...6.0.1)
+
+- [#305] Fix `JsBackedMap` for Dart 2.12.
+
 ## [6.0.0](https://github.com/cleandart/react-dart/compare/5.7.1...6.0.0)
 
 This stable, __major__ release of react includes:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 6.0.0
+version: 6.0.1
 authors:
   - Samuel Hapák <samuel.hapak@gmail.com>
   - Greg Littlefield <greg.littlefield@workiva.com>


### PR DESCRIPTION
This patch release includes

#305 Fix JsBackedMap for Dart 2.12