### PR TITLE
Remove deprecated authors field from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,5 @@
 name: react
 version: 6.0.1
-authors:
-  - Samuel Hapák <samuel.hapak@gmail.com>
-  - Greg Littlefield <greg.littlefield@workiva.com>
-  - Claire Sarsam <claire.sarsam@workiva.com>
-  - Aaron Lademann <aaron.lademann@workiva.com>
-  - Keal Jones <keal.jones@workiva.com>
-  - Joe Bingham <joe.bingham@workiva.com>
-  - Sydney Jodon <sydney.jodon@workiva.com>
-  - Smai Fullerton <smai.fullerton@workiva.com>
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:


### PR DESCRIPTION
This PR removes the author field from any `pubspec.yaml` files in this repo,
as the field was deprecated in Dart 2.7 and is no longer needed.

Removing this field will silence the warning that `pub publish` emits, which
has the added benefit of allowing us to use `pub publish --dry-run` as a
quality check during CI.

If you'd like to retain the author information, we recommend adding an
`AUTHORS.md` file in the repo or the package directory.

---

This PR was created automatically from a Sourcegraph batch change.
Please reach out to @evanweible-wf or #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/remove_pubspec_authors`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/remove_pubspec_authors)