### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/example/geocodes/geocodes.dart
+++ b/example/geocodes/geocodes.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 import 'dart:async';
 import 'dart:convert';

--- a/example/js_components/js_components.dart
+++ b/example/js_components/js_components.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @JS()
 library js_components;
 

--- a/example/test/call_and_nosuchmethod_test.dart
+++ b/example/test/call_and_nosuchmethod_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 import "dart:html";
 

--- a/example/test/context_test.dart
+++ b/example/test/context_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:html';
 
 import 'package:react/react.dart' as react;

--- a/example/test/false_and_null_test.dart
+++ b/example/test/false_and_null_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 import 'dart:html';
 

--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:html';
 import 'dart:math';
 

--- a/example/test/get_dom_node_test.dart
+++ b/example/test/get_dom_node_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 import "dart:html";
 

--- a/example/test/order_test.dart
+++ b/example/test/order_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 import 'dart:html';
 

--- a/example/test/react_test.dart
+++ b/example/test/react_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import "dart:html";
 
 import "package:react/react_dom.dart" as react_dom;

--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 import "dart:html";
 

--- a/example/test/speed_test.dart
+++ b/example/test/speed_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 import "dart:html";
 import "dart:async";

--- a/example/test/unmount_test.dart
+++ b/example/test/unmount_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 import "dart:html";
 

--- a/test/factory/dart_factory_test.dart
+++ b/test/factory/dart_factory_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 library react.dart_factory_test;
 

--- a/test/factory/dart_function_factory_test.dart
+++ b/test/factory/dart_function_factory_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 // ignore_for_file: invalid_use_of_protected_member
 @TestOn('browser')

--- a/test/factory/dom_factory_test.dart
+++ b/test/factory/dom_factory_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 library react.dom_factory_test;
 

--- a/test/factory/js_factory_test.dart
+++ b/test/factory/js_factory_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @JS()
 @TestOn('browser')
 library react.js_factory_test;

--- a/test/forward_ref_test.dart
+++ b/test/forward_ref_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 library react.forward_ref_test;
 

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 @JS()
 library hooks_test;

--- a/test/js_builds/js_dev_test.dart
+++ b/test/js_builds/js_dev_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:react/react_client.dart';
 import 'package:test/test.dart';

--- a/test/js_builds/js_dev_with_addons_test.dart
+++ b/test/js_builds/js_dev_with_addons_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:react/react_client.dart';
 import 'package:test/test.dart';

--- a/test/js_builds/js_prod_combined_test.dart
+++ b/test/js_builds/js_prod_combined_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:react/react_client.dart';
 import 'package:test/test.dart';

--- a/test/js_builds/js_prod_test.dart
+++ b/test/js_builds/js_prod_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:react/react_client.dart';
 import 'package:test/test.dart';

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 @TestOn('browser')
 @JS()

--- a/test/react_client/bridge_test.dart
+++ b/test/react_client/bridge_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 library react.bridge_test;
 

--- a/test/react_client/chain_refs_test.dart
+++ b/test/react_client/chain_refs_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 @JS()
 library react.chain_refs_test;

--- a/test/react_client/event_helpers_test.dart
+++ b/test/react_client/event_helpers_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 library react.event_helpers_test;
 

--- a/test/react_client/js_backed_map_test.dart
+++ b/test/react_client/js_backed_map_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 @JS()
 library react.js_backed_map_test.dart;

--- a/test/react_client/react_interop_test.dart
+++ b/test/react_client/react_interop_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 library react.react_interop_test;
 

--- a/test/react_client_test.dart
+++ b/test/react_client_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 @TestOn('browser')
 @JS()

--- a/test/react_component_test.dart
+++ b/test/react_component_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // ignore_for_file: deprecated_member_use_from_same_package
 @TestOn('browser')
 

--- a/test/react_context_test.dart
+++ b/test/react_context_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 @JS()
 library react_test_utils_test;

--- a/test/react_fragment_test.dart
+++ b/test/react_fragment_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 @JS()
 library react_test_utils_test;

--- a/test/react_memo_test.dart
+++ b/test/react_memo_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 library react.react_memo_test;
 

--- a/test/react_strictmode_test.dart
+++ b/test/react_strictmode_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 @JS()
 library react_test_utils_test;

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 library react_test_utils_test;
 

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 library react.util_test;
 

--- a/tool/run_consumer_tests.dart
+++ b/tool/run_consumer_tests.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:io';
 
 import 'package:args/args.dart';


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)