### PR TITLE
CPLAT-15062 Export generateJsProps

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: dart pub get
 
       - name: Validate dependencies
-        run: dart pub run dependency_validator -i build_runner,build_test,build_web_compilers
+        run: dart pub run dependency_validator -i build_runner,build_test,build_web_compilers,meta
         if: always() && steps.install.outcome == 'success'
 
       # TODO: Uncomment this, and remove the Dart 2.7.2 format step in the Workiva Build Dockerfile

--- a/lib/react_client/component_factory.dart
+++ b/lib/react_client/component_factory.dart
@@ -17,7 +17,7 @@ import 'package:react/src/typedefs.dart';
 import 'package:react/src/react_client/factory_util.dart';
 
 // ignore: deprecated_member_use_from_same_package
-export 'package:react/src/react_client/factory_util.dart' show unconvertJsEventHandler;
+export 'package:react/src/react_client/factory_util.dart' show generateJsProps, unconvertJsEventHandler;
 
 /// Prepares [children] to be passed to the ReactJS [React.createElement] and
 /// the Dart [react.Component].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 dependencies:
   js: ^0.6.0
-  meta: ^1.1.6
+  meta: ">=1.1.6 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
 dev_dependencies:
   args: ^1.5.1
   build_runner: ^1.6.5


### PR DESCRIPTION
## Motivation
`generateJsProps` is used in `ReactComponentFactoryProxy` classes to construct `React.createElement`-compatible JS props objects from Dart props Maps, and includes conversion of refs and optional deep jsifiation of nested objects.

`React.createElement` is the primary recipient of these kinds of JS props objects, but there are cases in which consumers may need to pass those props to other JS recipients. 

For example, you may want to call a JS callback with those props, or even opt to perform conversion of props before they get to the `ReactComponentFactoryProxy`.


## Solution
- Export `generateJsProps` as a public API

#### Unrelated changes
- Fix build by pinning meta

## Testing Steps
N/A (CI passes)