### PR TITLE
RM-110959 Release react-dart 6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [6.1.1](https://github.com/cleandart/react-dart/compare/6.1.0...6.1.1)
+
+- [#319] Add `baseURI` polyfill for IE 11 compatibility on Dart 2.13.
+
 ## [6.1.0](https://github.com/cleandart/react-dart/compare/6.0.1...6.1.0)
 
 - [#316] Export `generateJsProps`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 6.1.0
+version: 6.1.1
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:


### PR DESCRIPTION
This release includes #319 Add `baseURI` polyfill for IE 11 compatibility on Dart 2.13.