### PR TITLE
Upgrade dependency_validator

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: dart pub get
 
       - name: Validate dependencies
-        run: dart pub run dependency_validator -i build_runner,build_test,build_web_compilers,meta
+        run: dart dart run dependency_validator
         if: always() && steps.install.outcome == 'success'
 
      - name: Verify formatting

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [stable, beta]
+        sdk: [2.13.4, stable, beta]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.1

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -30,9 +30,9 @@ jobs:
         run: dart run dependency_validator
         if: always() && steps.install.outcome == 'success'
 
-     - name: Verify formatting
-       run: dart format --output=none --line-length=120 --set-exit-if-changed .
-       if: always() && ${{ matrix.sdk }} == 'stable' && steps.install.outcome == 'success'
+      - name: Verify formatting
+        run: dart format --output=none --line-length=120 --set-exit-if-changed .
+        if: always() && ${{ matrix.sdk }} == 'stable' && steps.install.outcome == 'success'
 
       - name: Analyze project source
         run: dart analyze

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,9 +15,9 @@ jobs:
         sdk: [2.13.4, stable, beta]
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v0.1
+      - uses: dart-lang/setup-dart@v1
         with:
-          channel: ${{ matrix.sdk }}
+          sdk: ${{ matrix.sdk }}
 
       - name: Print Dart SDK version
         run: dart --version

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: dart pub get
 
       - name: Validate dependencies
-        run: dart dart run dependency_validator
+        run: dart run dependency_validator
         if: always() && steps.install.outcome == 'success'
 
      - name: Verify formatting

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,3 +16,7 @@ dev_dependencies:
   matcher: ^0.12.5
   mockito: ">=4.1.1 <6.0.0"
   test: ^1.6.5
+
+dependency_validator:
+  ignore:
+    - meta # ignore the pin for now

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dev_dependencies:
   build_runner: ^1.6.5
   build_test: ^0.10.8
   build_web_compilers: ^2.12.0
-  dependency_validator: ^1.2.0
+  dependency_validator: ^2.0.0
   matcher: ^0.12.5
   mockito: ">=4.1.1 <6.0.0"
   test: ^1.6.5


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades


This batch is to find and open PRs to upgrade dependency_validator to v2.

Additional manual work that might be needed (CP will do):
 [ ] Run dependency_validator to repos that aren't running it,
   but do have the dependency. 
 [ ] Fix CI due to removing an ignore that was actually needed.

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/update_dep_validator`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/update_dep_validator)