### PR TITLE
RM-113709 Release react-dart 6.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [6.1.3](https://github.com/cleandart/react-dart/compare/6.1.2...6.1.3)
+
+- [#308] Bump elliptic from 6.5.3 to 6.5.4
+- [#311] Bump ssri from 6.0.1 to 6.0.2
+- [#312] Bump lodash from 4.17.20 to 4.17.21
+- [#313] Bump browserslist from 4.16.1 to 4.16.6
+- [#318] Bump path-parse from 1.0.6 to 1.0.7
+- [#323] Raise the Dart SDK minimum to at least 2.11.0
+- [#315] Upgrade CI to run using Dart 2.13
+- [#309] Update README.md
+- [#325] Upgrade dependency_validator
+
 ## [6.1.2](https://github.com/cleandart/react-dart/compare/6.1.1...6.1.2)
 
 - [#321] Fix missing Dart component names in error boundary `componentStack`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 6.1.2
+version: 6.1.3
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump elliptic from 6.5.3 to 6.5.4](https://github.com/Workiva/react-dart/pull/308)
	* [Update README.md](https://github.com/Workiva/react-dart/pull/309)
	* [Bump ssri from 6.0.1 to 6.0.2](https://github.com/Workiva/react-dart/pull/311)
	* [Bump lodash from 4.17.20 to 4.17.21](https://github.com/Workiva/react-dart/pull/312)
	* [Bump browserslist from 4.16.1 to 4.16.6](https://github.com/Workiva/react-dart/pull/313)
	* [Upgrade to Dart 2.13](https://github.com/Workiva/react-dart/pull/315)
	* [Bump path-parse from 1.0.6 to 1.0.7](https://github.com/Workiva/react-dart/pull/318)
	* [Raise the Dart SDK minimum to at least 2.11.0](https://github.com/Workiva/react-dart/pull/323)
	* [Upgrade dependency_validator](https://github.com/Workiva/react-dart/pull/325)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/react-dart/compare/6.1.2...Workiva:release_react-dart_6.1.3
Diff Between Last Tag and New Tag: https://github.com/Workiva/react-dart/compare/6.1.2...6.1.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4743698779471872/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4743698779471872/?pull_number=326&repo_name=Workiva%2Freact-dart)