### PR TITLE
Fix stable ci build

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -2,9 +2,12 @@ name: Dart CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - 'master'
+      - 'test_consume_*'
   pull_request:
-    branches: [ master ]
+    branches:
+      - '*'
 
 jobs:
   build:
@@ -32,18 +35,20 @@ jobs:
 
       - name: Verify formatting
         run: dart format --output=none --line-length=120 --set-exit-if-changed .
-        if: always() && ${{ matrix.sdk }} == 'stable' && steps.install.outcome == 'success'
+        if: ${{ matrix.sdk == '2.13.4' }}
 
       - name: Analyze project source
         run: dart analyze
         if: always() && steps.install.outcome == 'success'
 
       - name: Run tests (DDC)
-        run: dart pub run build_runner test -- --preset dartdevc
+        run: |
+          if [ ${{ matrix.sdk }} = '2.13.4' ]; then dart run build_runner test -- --preset dartdevc-legacy; else dart run build_runner test -- --preset dartdevc; fi
         if: always() && steps.install.outcome == 'success'
         timeout-minutes: 5
 
       - name: Run tests (dart2js)
-        run: dart pub run build_runner test --release -- --preset dart2js
+        run: |
+          if [ ${{ matrix.sdk }} = '2.13.4' ]; then dart run build_runner test -- --preset dart2js-legacy; else dart run build_runner test -- --preset dart2js; fi
         if: always() && steps.install.outcome == 'success'
         timeout-minutes: 5

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -5,11 +5,17 @@ platforms:
   - vm
 
 presets:
-  dart2js:
+  dart2js-legacy:
     exclude_tags: no-dart2js
 
-  dartdevc:
+  dartdevc-legacy:
     exclude_tags: no-dartdevc
+
+  dart2js:
+    exclude_tags: "no-dart2js || no-sdk-2-14-plus"
+
+  dartdevc:
+    exclude_tags: "no-dartdevc || no-sdk-2-14-plus"
 
 tags:
   # Variadic children tests of >5 children that fail in Dart 2.7 for an unknown reason, seemingly an SDK bug.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,17 +6,13 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 dependencies:
   js: ^0.6.0
-  meta: ">=1.1.6 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
+  meta: ^1.1.6
 dev_dependencies:
-  args: ^1.5.1
-  build_runner: ^1.6.5
-  build_test: ^0.10.8
-  build_web_compilers: ^2.12.0
-  dependency_validator: ^2.0.0
+  args: ">=1.5.1 <3.0.0"
+  build_runner: ">=1.6.5 <3.0.0"
+  build_test: ">=0.10.8 <3.0.0"
+  build_web_compilers: ">=2.12.0 <4.0.0"
+  dependency_validator: ">=2.0.0 <4.0.0"
   matcher: ^0.12.5
   mockito: ">=4.1.1 <6.0.0"
   test: ^1.6.5
-
-dependency_validator:
-  ignore:
-    - meta # ignore the pin for now

--- a/test/js_builds/shared_tests.dart
+++ b/test/js_builds/shared_tests.dart
@@ -129,7 +129,7 @@ void sharedConsoleWarnTests({@required bool expectDeduplicateSyntheticEventWarni
           ]);
         });
       }
-    }, tags: 'no-dart2js');
+    }, tags: ['no-dart2js', 'no-sdk-2-14-plus']);
 
     test('logs other duplicate messages properly', () {
       consoleWarn('foo');


### PR DESCRIPTION
In order to get the CI build passing on 2.13.4 and 2.14.x (stable), we need to widen some dependency ranges.

It also appears that https://github.com/dart-lang/sdk/issues/43939 was fixed at some point in the 2.14.x line of release _(thus the new tag used to skip those dupe `console.warn` tests unless we're running the tests in 2.13.x)_.