### PR TITLE
Temporarily disable the mockito builder for better build perf

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,11 @@
 targets:
   $default:
     builders:
+      # mockito's builder is expensive and is not needed until this package is
+      # migrated to null-safety. At that point, it should be scoped only to
+      # relevant files.
+      mockito:mockBuilder:
+        enabled: false
       build_web_compilers|entrypoint:
         # These are globs for the entrypoints you want to compile.
         generate_for:


### PR DESCRIPTION
## What/Why

This batch temporarily disables the mockito builder because it is only
needed for NNBD code and the default behavior is for it to run on every
`.dart` file and fully resolve each of those files, which is slow.
**Disabling this builder should improve local and CI build times.**

## Testing

These changes should only disable a builder that is already not generating
anything for packages that have not yet migrated to null-safety. For that
reason, code review of the modification to the `build.yaml` and passing CI
should be sufficient testing.

## More Info

This batch change is a part of a larger Client Platform effort to update our
Dart dependencies and unblock us from upgrading to the latest Dart SDK.
More info can be found here: https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

If you have any questions or comments, please comment on this PR or reach
out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/disable_mockito_builder`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/disable_mockito_builder)