### PR TITLE
RM-138703 Release react-dart 6.1.6 (Publish JS bundles to Workiva CDN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [6.1.6](https://github.com/cleandart/react-dart/compare/6.1.5...6.1.6)##
+- [#336] Publish JS bundles to Workiva CDN
+
 ## [6.1.5](https://github.com/cleandart/react-dart/compare/6.1.4...6.1.5)##
 - [#333] Remove old, unused file from bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 FROM google/dart:2.13
+
+WORKDIR /build
 COPY pubspec.yaml .
+COPY /lib ./lib/
+
 RUN dart pub get
+
+RUN cd lib && tar -czvf ../cdn_assets.tar.gz *.js
+ARG BUILD_ARTIFACTS_CDN=/build/cdn_assets.tar.gz
+
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM google/dart:2.13
 
 WORKDIR /build
 COPY pubspec.yaml .
-COPY /lib ./lib/
 
 RUN dart pub get
 
+COPY /lib ./lib/
 RUN cd lib && tar -czvf ../cdn_assets.tar.gz *.js
 ARG BUILD_ARTIFACTS_CDN=/build/cdn_assets.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY pubspec.yaml .
 RUN dart pub get
 
 COPY /lib ./lib/
-RUN cd lib && tar -czvf ../cdn_assets.tar.gz *.js
+RUN cd lib && tar -czvf ../cdn_assets.tar.gz *.js *.map
 ARG BUILD_ARTIFACTS_CDN=/build/cdn_assets.tar.gz
 
 FROM scratch

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 6.1.5
+version: 6.1.6
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,0 +1,18 @@
+name: validate_cdn_artifact
+description: Verifies the cdn artifact generated in the build contains the JS bundle files
+image: drydock.workiva.net/workiva/skynet-images:node-test-image-latest
+size: large
+timeout: 900
+
+requires:
+  Workiva/react-dart:
+    - cdn
+
+scripts:
+  - mkdir build
+  - cp $SKYNET_APPLICATION_REACT_DART_CDN ./build
+  - cd build
+  - tar -xf cdn_assets.tar.gz
+  - test -e ./react.js && { echo 'Verified dev bundle exists in CDN artifact.'; } || { echo 'Dev bundle /lib/react.js should exist in CDN artifact.'; exit 1; }
+  - test -e ./react_dom.js && { echo 'Verified dev DOM bundle exists in CDN artifact.'; } || { echo 'Dev DOM bundle /lib/react_dom.js should exist in CDN artifact.'; exit 1; }
+  - test -e ./react_with_react_dom_prod.js && { echo 'Verified prod bundle exists in CDN artifact.'; } || { echo 'Prod bundle /lib/react_with_react_dom_prod.js should exist in CDN artifact.'; exit 1; }

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -16,3 +16,5 @@ scripts:
   - test -e ./react.js && { echo 'Verified dev bundle exists in CDN artifact.'; } || { echo 'Dev bundle /lib/react.js should exist in CDN artifact.'; exit 1; }
   - test -e ./react_dom.js && { echo 'Verified dev DOM bundle exists in CDN artifact.'; } || { echo 'Dev DOM bundle /lib/react_dom.js should exist in CDN artifact.'; exit 1; }
   - test -e ./react_with_react_dom_prod.js && { echo 'Verified prod bundle exists in CDN artifact.'; } || { echo 'Prod bundle /lib/react_with_react_dom_prod.js should exist in CDN artifact.'; exit 1; }
+  - test -e ./react_prod.js && { echo 'Verified prod bundle exists in CDN artifact.'; } || { echo 'Prod bundle /lib/react_prod.js should exist in CDN artifact.'; exit 1; }
+  - test -e ./react_dom_prod.js && { echo 'Verified prod DOM bundle exists in CDN artifact.'; } || { echo 'Prod DOM bundle /lib/react_dom_prod.js should exist in CDN artifact.'; exit 1; }


### PR DESCRIPTION
Now that we've moved this package within the Workiva org, we should publish the JS bundles to our CDN so that Workiva customers get assets cached based on the react package version, not the Workiva application version.