### PR TITLE
Replace deprecated commands with new dart commands

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # Serving / Viewing React Dart Examples
 
-1. Run `pub get` in your terminal. 
+1. Run `dart pub get` in your terminal. 
 2. Run `webdev serve example`.
 2. Open Chrome.
 3. Navigate to <http://localhost:8080>

--- a/tool/run_consumer_tests.dart
+++ b/tool/run_consumer_tests.dart
@@ -65,7 +65,7 @@ dependency_overrides:
   var pubspecSrc = pubspec.readAsStringSync();
   pubspecSrc = pubspecSrc.replaceFirst('dependencies:', '${dependencyOverrides}dependencies:');
   pubspec.writeAsStringSync(pubspecSrc);
-  final pubGetProcess = await Process.start('pub', ['get'], mode: ProcessStartMode.inheritStdio);
+  final pubGetProcess = await Process.start('dart', ['pub', 'get'], mode: ProcessStartMode.inheritStdio);
   await pubGetProcess.exitCode;
 
   final testArgs = testCmdStr.split(' ');


### PR DESCRIPTION
This Sourcegraph batch replaces deprecated commands from the Dart SDK with the new ones.
All new CLI commands now live under the main `dart` executable. See this issue for the details
https://github.com/dart-lang/sdk/issues/46100

This PR might need to be checked or tweaked for possible errors in the arguments to 
`dart analyze` and `dart format` since they take slightly different arguments than the original.
In most cases for analyze all the arguments can be removed and it can just be `dart analyze`.

Some of the argument changes were difficult to match and replace in an automated way. Since
there are only a few places that might break, it'll be easier to let the batch create the PR
and then manually adjust them.

### Argument changes for dartfmt -> dart format
`-w` should be removed automatically since overwriting files is now the default. But, if you spot one, remove it.
`--dry-run` is not a supported argument now. Replace with `--set-exit-if-changed -o none`

repos that look like they will need updates for dart format
- abide
- abide_archived
- bender.dart
- unscripted (unused repo)

### Argument changes for dartanalyzer -> dart analyze
`--no-hints` and `--no-lints` are removed

repos that look like they will need updates for dart analyze
- user_analytics


### QA steps:

- CI passing is a great start since these commands are usually called in the dockerfile, shell scripts, or skynet
- Check the changeset and if there are scripts that are only run locally and not in CI, try running them locally to verify they work
- If the PR has changes to `dart analyze` or `dart format` check the arguments
- Lastly, look for replacements that matched in the wrong place and should be undone or fixed

[_Created by Sourcegraph batch change `Workiva/dart_commands`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_commands)