### PR TITLE
FW-151 Add skynet config that verifies that github workflow is successful

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -24,15 +24,9 @@ scripts:
 name: verify-github-actions
 description: Verify that the github actions run passed, this is needed to make pipelines pass without manual intervention
 contact: 'Frontend Frameworks Architecture / #support-frontend-architecture'
-image: drydock.workiva.net/workiva/skynet-images:3708893 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
+image: drydock.workiva.net/workiva/skynet-images:3728345 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
 size: small
 timeout: 600
-
-run:
-  on-pull-request: false
-  on-promotion: true
-  when-modified-file-name-is: 
-    - skynet.yaml
 
 env:
 # encrypted github token used for requests to api.github.com

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -18,3 +18,19 @@ scripts:
   - test -e ./react_with_react_dom_prod.js && { echo 'Verified prod bundle exists in CDN artifact.'; } || { echo 'Prod bundle /lib/react_with_react_dom_prod.js should exist in CDN artifact.'; exit 1; }
   - test -e ./react_prod.js && { echo 'Verified prod bundle exists in CDN artifact.'; } || { echo 'Prod bundle /lib/react_prod.js should exist in CDN artifact.'; exit 1; }
   - test -e ./react_dom_prod.js && { echo 'Verified prod DOM bundle exists in CDN artifact.'; } || { echo 'Prod DOM bundle /lib/react_dom_prod.js should exist in CDN artifact.'; exit 1; }
+
+---
+
+name: verify-github-actions
+description: Verify that the github actions run passed, this is needed to make pipelines pass without manual intervention
+contact: 'Frontend Frameworks Architecture / #support-frontend-architecture'
+image: drydock.workiva.net/workiva/skynet-images:3693290 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
+size: small
+timeout: 600
+
+env:
+# encrypted github token used for requests to api.github.com
+ - secure: wqV2dUVmOMNZgll+/Sr4fra76p+gTvqRS3QvNQASg3hzoysFz7enBaKsXKXoPFj+jexOvFVN/m4rko272z/xZ6lBMRI=
+
+scripts:
+  - python3 /actions/verify_github_actions.py

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -28,6 +28,12 @@ image: drydock.workiva.net/workiva/skynet-images:3693290 # Uses the image from t
 size: small
 timeout: 600
 
+run:
+  on-pull-request: false
+  on-promotion: true
+  when-modified-file-name-is: 
+    - skynet.yaml
+
 env:
 # encrypted github token used for requests to api.github.com
  - secure: wqV2dUVmOMNZgll+/Sr4fra76p+gTvqRS3QvNQASg3hzoysFz7enBaKsXKXoPFj+jexOvFVN/m4rko272z/xZ6lBMRI=


### PR DESCRIPTION
This adds a skynet config that verifies that the github workflow is successful this means that if the tests fail this will cause the release pipeline to fail with the current setup if the github workflow fails the pipeline will continue on like everything is fine when things could be very broken. This is a temporary fix with the hope that pipelines/CID will be able to just check the github workflow run instead of needing this.