### PR TITLE
Narrow dependency_validator range to avoid NNBD issue

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dev_dependencies:
   build_runner: ">=1.6.5 <3.0.0"
   build_test: ">=0.10.8 <3.0.0"
   build_web_compilers: ">=2.12.0 <4.0.0"
-  dependency_validator: ">=2.0.0 <4.0.0"
+  dependency_validator: ^2.0.0
   matcher: ^0.12.5
   mockito: ">=4.1.1 <6.0.0"
   test: ^1.6.5


### PR DESCRIPTION
We recently discovered that if a package resolves to `dependency_validator >=3.0.0`
and `build_config <1.0.0`, running the `dependency_validator` tool will fail
during precompilation due to null safety.

We are merging a fix to `dependency_validator`, but unfortunately it won't
prevent consumers from resolving to the v3.x versions that still have the
issue. This PR addresses the issue for consumers by narrowing the range to
no longer include `dependency_validator v3`.

Note: We originally widened this range as a part of the effort to upgrade
our ecosystem to `analyzer v1`, but it is not strictly necessary. Consumers
of `dependency_validator v2` can still successfully resolve to `analyzer v1`.

For more info, reach out to `#support-frontend-architecture` on Slack.

[_Created by Sourcegraph batch change `Workiva/narrow_dependency_validator_range`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/narrow_dependency_validator_range)