### PR TITLE
FED-358 Work around identityHashCode throwing for non-extensible objects

### DIFF
--- a/lib/react_client/js_interop_helpers.dart
+++ b/lib/react_client/js_interop_helpers.dart
@@ -12,8 +12,18 @@ import 'js_backed_map.dart';
 
 /// Like [identityHashCode], but uses a different hash for JS objects to work around an issue where
 /// [identityHashCode] adds an unwanted `$identityHash` property on JS objects (https://github.com/dart-lang/sdk/issues/47595).
-int _jsObjectFriendlyIdentityHashCode(Object object) =>
-    object is JsMap ? _jsObjectHashCode(object) : identityHashCode(object);
+int _jsObjectFriendlyIdentityHashCode(Object object) {
+  // Try detecting JS objects.
+  if (object is JsMap) return _jsObjectHashCode(object);
+  // There are some JS objects that will fail the above check and throw.
+  // In those cases, fall back to a safe implementation.
+  // FIXME(greg) find out what these cases are, document them, and add tests
+  try {
+    return identityHashCode(object);
+  } catch (_) {
+    return _jsObjectHashCode(object);
+  }
+}
 
 /// A hashCode implementation for JS objects.
 ///

--- a/test/react_client/js_interop_helpers_test.dart
+++ b/test/react_client/js_interop_helpers_test.dart
@@ -175,7 +175,7 @@ main() {
       });
 
       test('array object constructed in JS', () {
-        // Create this and freeze it on the JS side so that we're not starting out with Dart's list implementation
+        // Create this on the JS side so that we're not starting out with Dart's list implementation
         // and potentially any wrapper classes.
         final frozenArray = createArray();
         expect(_getPrototypeOf(frozenArray), _arrayPrototype, reason: 'test setup check; should be an array');

--- a/test/react_client/js_interop_helpers_test.dart
+++ b/test/react_client/js_interop_helpers_test.dart
@@ -50,6 +50,9 @@ class Foo {
   external num bar();
 }
 
+@JS()
+external dynamic createArray();
+
 main() {
   group('jsifyAndAllowInterop', () {
     test('converts a List', () {
@@ -131,5 +134,82 @@ main() {
       expect(objectKeys(convertedNestedJsObject), expectedProperties,
           reason: 'JS object should not have any additional properties');
     });
+
+    group('works as expected when the map contains frozen objects:', () {
+      test('anonymous object', () {
+        final frozenAnonymousObject = jsify({'foo': 'bar'});
+        expect(_getPrototypeOf(frozenAnonymousObject), _objectPrototype,
+            reason: 'test setup check; should not extend from another JS type');
+
+        _freeze(frozenAnonymousObject);
+        expect(_isFrozen(frozenAnonymousObject), isTrue, reason: 'test setup check; should have frozen');
+
+        dynamic jsObject;
+        expect(() {
+          jsObject = jsifyAndAllowInterop({
+            'frozenObject': frozenAnonymousObject,
+          });
+        }, returnsNormally, reason: 'should not throw when it encounters a frozen object');
+        final convertedNestedFrozenObject = getProperty(jsObject, 'frozenObject');
+        expect(convertedNestedFrozenObject, same(frozenAnonymousObject),
+            reason: 'JS object should have just gotten passed through');
+      });
+
+      test('non-anonymous object', () {
+        final frozenNonAnynymousObject = Foo(21);
+        expect(_getPrototypeOf(frozenNonAnynymousObject), isNot(_objectPrototype),
+            reason: 'test setup check; should extend from another JS type');
+
+        _freeze(frozenNonAnynymousObject);
+        expect(_isFrozen(frozenNonAnynymousObject), isTrue, reason: 'test setup check; should have frozen');
+
+        dynamic jsObject;
+        expect(() {
+          jsObject = jsifyAndAllowInterop({
+            'frozenObject': frozenNonAnynymousObject,
+          });
+        }, returnsNormally, reason: 'should not throw when it encounters a frozen object');
+        final convertedNestedFrozenObject = getProperty(jsObject, 'frozenObject');
+        expect(convertedNestedFrozenObject, same(frozenNonAnynymousObject),
+            reason: 'JS object should have just gotten passed through');
+      });
+
+      test('array object constructed in JS', () {
+        // Create this and freeze it on the JS side so that we're not starting out with Dart's list implementation
+        // and potentially any wrapper classes.
+        final frozenArray = createArray();
+        expect(_getPrototypeOf(frozenArray), _arrayPrototype, reason: 'test setup check; should be an array');
+
+        _freeze(frozenArray);
+        expect(_isFrozen(frozenArray), isTrue, reason: 'test setup check; should have frozen');
+
+        dynamic jsObject;
+        expect(() {
+          jsObject = jsifyAndAllowInterop({
+            'frozenArray': frozenArray,
+          });
+        }, returnsNormally, reason: 'should not throw when it encounters a frozen object');
+        final convertedNestedFrozenObject = getProperty(jsObject, 'frozenArray');
+        // Note that we don't expect it to be `same(frozenArray)` since the array passes the `is Iterable` check,
+        // and thus gets processed in _convertDataTree.
+        expect(convertedNestedFrozenObject, equals(frozenArray),
+            reason: 'JS object should have been converted properly passed through');
+      });
+    });
   });
 }
+
+@JS('Object.prototype')
+external dynamic get _objectPrototype;
+
+@JS('Array.prototype')
+external dynamic get _arrayPrototype;
+
+@JS('Object.freeze')
+external void _freeze(Object object);
+
+@JS('Object.isFrozen')
+external bool _isFrozen(Object object);
+
+@JS('Object.getPrototypeOf')
+external dynamic _getPrototypeOf(Object object);

--- a/test/react_client/js_interop_helpers_test.html
+++ b/test/react_client/js_interop_helpers_test.html
@@ -20,6 +20,10 @@
           else
             return false;
         }
+
+        function createArray() {
+          return [1, 2, 3];
+        }
     </script>
 
     <link rel="x-dart-test" href="js_interop_helpers_test.dart">


### PR DESCRIPTION
## Motivation
Currently, when jsifyAndAllowInterop encounters a non-JsObject frozen object, such as [the frozen `children` array](https://github.com/facebook/react/blob/1ad8d81292415e26ac070dec03ad84c11fbe207d/packages/react/src/ReactElement.js#L413) of a JSX Element, it throws as a result of `identityHashCode` trying to write a property on it (Dart SDK issue: https://github.com/dart-lang/sdk/issues/36354).


This can occur when wrapping JS components in Dart and forwarding props that contain frozen arrays them to another component.
```
Uncaught TypeError: Cannot add property Symbol(_identityHashCode), object is not extensible
    at Object.identityHashCode (core_patch.dart:41:42)
    at CustomHashMap.new._jsObjectFriendlyIdentityHashCode (js_interop_helpers.dart:16:51)
    at CustomHashMap.new.containsKey (custom_hash_map.dart:72:70)
    at _convert (js_interop_helpers.dart:84:26)
    at _convert (js_interop_helpers.dart:91:40)
    at Object._convertDataTree (js_interop_helpers.dart:108:10)
    at Object.jsifyAndAllowInterop (js_interop_helpers.dart:75:10)
    at Object.generateJsProps (factory_util.dart:123:26)
    at component_factory.ReactDomComponentFactoryProxy.new.build (component_factory.dart:304:26)
    at dom_components.DomProps.new.call (component_base.dart:639:29)
```

Note that this error only happens in DDC, since dart2js does not run in strict mode

## Solution
- Wrap call to identityHashCode in a try-catch, and fall back to a safe implementation
- Update code comments
- Add regression tests.

## Testing
- Verify regression tests pass in DDC (i.e., CI passes) 

## Release notes
- Fix identityHashCode error when forwarding props containing JSX children