### PR TITLE
RM-139349 Release react-dart 6.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-## [6.1.6](https://github.com/cleandart/react-dart/compare/6.1.5...6.1.6)##
+## [6.1.7](https://github.com/cleandart/react-dart/compare/6.1.6...6.1.7)
+- [#344] Fix identityHashCode error when forwarding props containing JSX children
+
+## [6.1.6](https://github.com/cleandart/react-dart/compare/6.1.5...6.1.6)
 - [#336] Publish JS bundles to Workiva CDN
 
-## [6.1.5](https://github.com/cleandart/react-dart/compare/6.1.4...6.1.5)##
+## [6.1.5](https://github.com/cleandart/react-dart/compare/6.1.4...6.1.5)
 - [#333] Remove old, unused file from bin/
 
 ## [6.1.4](https://github.com/cleandart/react-dart/compare/6.1.3...6.1.4)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 6.1.6
+version: 6.1.7
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump minimist from 1.2.5 to 1.2.6](https://github.com/Workiva/react-dart/pull/335)
	* [Bump ansi-regex from 4.1.0 to 4.1.1](https://github.com/Workiva/react-dart/pull/338)
	* [Replace deprecated commands with new dart commands](https://github.com/Workiva/react-dart/pull/340)
	* [FW-151 Add skynet config that verifies that github workflow is successful](https://github.com/Workiva/react-dart/pull/341)
	* [Narrow dependency_validator range to avoid NNBD issue](https://github.com/Workiva/react-dart/pull/342)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/react-dart/compare/6.1.6...Workiva:release_react-dart_6.1.7
Diff Between Last Tag and New Tag: https://github.com/Workiva/react-dart/compare/6.1.6...6.1.7

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4743698779471872/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4743698779471872/?repo_name=Workiva%2Freact-dart&pull_number=345)