### PR TITLE
Add a ReactElementFactory typedef

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -47,6 +47,8 @@ typedef DartForwardRefFunctionComponent = dynamic Function(JsBackedMap props, dy
 
 typedef T ComponentFactory<T extends Component>();
 
+typedef ReactElementFactory = ReactElement Function();
+
 typedef ReactComponentFactoryProxy ComponentRegistrar(ComponentFactory componentFactory,
     [Iterable<String> skipMethods]);
 


### PR DESCRIPTION
When developing a large frontend application that consists of many different Dart package, all using React for the UI, it can be useful to pass around functions that return `ReactElement`. It is natural to want to define a typedef for such a function.

However, because of how `typedefs` work in Dart, all Dart packages that are using this typedef need to depend on some common dependency.

What better common dependency than react itself?!