### PR TITLE
FED-202 Return `jsUndefined` instead of `null` when children prop is empty

### DIFF
--- a/lib/src/react_client/factory_util.dart
+++ b/lib/src/react_client/factory_util.dart
@@ -83,7 +83,7 @@ dynamic generateChildren(List childrenArgs, {bool shouldAlwaysBeList = false}) {
   var children;
 
   if (childrenArgs.isEmpty) {
-    if (!shouldAlwaysBeList) return null;
+    if (!shouldAlwaysBeList) return jsUndefined;
     children = childrenArgs;
   } else if (childrenArgs.length == 1) {
     if (shouldAlwaysBeList) {

--- a/test/factory/js_factory_test.dart
+++ b/test/factory/js_factory_test.dart
@@ -5,9 +5,9 @@ library react.js_factory_test;
 import 'dart:html';
 
 import 'package:js/js.dart';
+import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
 import 'package:react/react_client/react_interop.dart';
-import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_test_utils.dart';
 import 'package:test/test.dart';
 
@@ -57,7 +57,9 @@ main() {
     });
 
     test('with no children returns JS undefined', () {
-      expect(() => react_dom.render(JsNoChildren({}), Element.div()), returnsNormally);
+      expect(hasUndefinedChildren(react.div({})), isTrue);
+      expect(hasUndefinedChildren(react.div({}, jsNull)), isFalse,
+          reason: 'Sanity check that JS `null` is not the same as JS `undefined`');
     });
   });
 }
@@ -71,5 +73,4 @@ external ReactClass get _JsFooFunction;
 final JsFooFunction = new ReactJsComponentFactoryProxy(_JsFooFunction);
 
 @JS()
-external ReactClass get _JsNoChildren;
-final JsNoChildren = new ReactJsComponentFactoryProxy(_JsNoChildren);
+external bool Function(ReactElement) get hasUndefinedChildren;

--- a/test/factory/js_factory_test.dart
+++ b/test/factory/js_factory_test.dart
@@ -7,6 +7,7 @@ import 'dart:html';
 import 'package:js/js.dart';
 import 'package:react/react_client.dart';
 import 'package:react/react_client/react_interop.dart';
+import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_test_utils.dart';
 import 'package:test/test.dart';
 
@@ -54,6 +55,10 @@ main() {
         expect(JsFooFunction.type, equals(_JsFooFunction));
       });
     });
+
+    test('with no children returns JS undefined', () {
+      expect(() => react_dom.render(JsNoChildren({}), Element.div()), returnsNormally);
+    });
   });
 }
 
@@ -64,3 +69,7 @@ final JsFoo = new ReactJsComponentFactoryProxy(_JsFoo);
 @JS()
 external ReactClass get _JsFooFunction;
 final JsFooFunction = new ReactJsComponentFactoryProxy(_JsFooFunction);
+
+@JS()
+external ReactClass get _JsNoChildren;
+final JsNoChildren = new ReactJsComponentFactoryProxy(_JsNoChildren);

--- a/test/factory/js_factory_test.js
+++ b/test/factory/js_factory_test.js
@@ -8,12 +8,4 @@ window._JsFooFunction = React.forwardRef((props, ref) => (
   React.createElement("div", {...props, ref: ref})
 ));
 
-window._JsNoChildren = class JsNoChildrenComponent extends React.Component {
-  render() {
-    if(this.props.children !== undefined) {
-      throw Error('children prop must be undefined');
-    }
-
-    return React.createElement("div", this.props);
-  }
-};
+window.hasUndefinedChildren = (reactElement) => reactElement.props.children === undefined;

--- a/test/factory/js_factory_test.js
+++ b/test/factory/js_factory_test.js
@@ -7,3 +7,13 @@ window._JsFoo = class JsFooComponent extends React.Component {
 window._JsFooFunction = React.forwardRef((props, ref) => (
   React.createElement("div", {...props, ref: ref})
 ));
+
+window._JsNoChildren = class JsNoChildrenComponent extends React.Component {
+  render() {
+    if(this.props.children !== undefined) {
+      throw Error('children prop must be undefined');
+    }
+
+    return React.createElement("div", this.props);
+  }
+};


### PR DESCRIPTION
Some JS components, like `Tab` expect no children to be passed to them.

However, when rendered from Dart, Tab's propTypes warn about children not being supported, even when no children are provided:
```
react.js:6902 Warning: Failed prop type: The prop `children` is not supported. Please remove it.
    at Tab (http://localhost:8080/packages/react_material_ui/react-material-ui-development.umd.js:46607:19)
```

This is because, when there are no children, `ReactJsComponentFactoryProxy` passes `null` into createElement, and the `unsupportedProp` validation checks warns when the prop is undefined.

## Changes

- Return `jsUndefined` instead of `null` from `generateChildren` when the children prop is empty
- Add regression test

## QA Instructions

- [ ] Verify CI passes
- [ ] Verify good test coverage