### PR TITLE
RM-156571 Release react-dart 6.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [6.1.8](https://github.com/cleandart/react-dart/compare/6.1.7...6.1.8)
+- [#350] Return `jsUndefined` instead of `null` when children prop is empty
+
 ## [6.1.7](https://github.com/cleandart/react-dart/compare/6.1.6...6.1.7)
 - [#344] Fix identityHashCode error when forwarding props containing JSX children
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 6.1.7
+version: 6.1.8
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FED-202 Return `jsUndefined` instead of `null` when children prop is empty](https://github.com/Workiva/react-dart/pull/350)


Requested by: @sydneyjodon-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/react-dart/compare/6.1.7...Workiva:release_react-dart_6.1.8
Diff Between Last Tag and New Tag: https://github.com/Workiva/react-dart/compare/6.1.7...6.1.8

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4743698779471872/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4743698779471872/?repo_name=Workiva%2Freact-dart&pull_number=351)