### PR TITLE
RM-171359 Release react-dart 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## [6.2.0](https://github.com/cleandart/react-dart/compare/6.1.8...6.2.0)
-* Patch changes:
 	* [#357] Export Suspense component
 	* [#354] Raise analyzer minimum & unpin meta
 	* [#355] Pin mockito 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [6.2.0](https://github.com/cleandart/react-dart/compare/6.1.8...6.2.0)
-	* [#357] Export Suspense component
-	* [#354] Raise analyzer minimum & unpin meta
-	* [#355] Pin mockito 5
-	* [#356] Unpin mockito, fix CI
+- [#357] Export Suspense component
+- [#354] Raise analyzer minimum & unpin meta
+- [#355] Pin mockito 5
+- [#356] Unpin mockito, fix CI
 
 ## [6.1.8](https://github.com/cleandart/react-dart/compare/6.1.7...6.1.8)
 - [#350] Return `jsUndefined` instead of `null` when children prop is empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [6.2.0](https://github.com/cleandart/react-dart/compare/6.1.8...6.2.0)
+* Patch changes:
+	* [#357] Export Suspense component
+	* [#354] Raise analyzer minimum & unpin meta
+	* [#355] Pin mockito 5
+	* [#356] Unpin mockito, fix CI
+
 ## [6.1.8](https://github.com/cleandart/react-dart/compare/6.1.7...6.1.8)
 - [#350] Return `jsUndefined` instead of `null` when children prop is empty
 
@@ -57,16 +64,16 @@ The underlying `.js` files provided by this package are now ReactJS version `17.
 
 ## [5.7.1](https://github.com/cleandart/react-dart/compare/5.7.0...5.7.1)
 
-- [#289] Update most deprecations that were slated for removal in v6.0.0 to be slated for removal in v7.0.0 instead. To keep the migration to v6.0.0 as easy as possible, only APIs that are known to be completely unused will be removed in v6.0.0. Therefore, most APIs that were marked for removal in v6.0.0 will remain until the v7.0.0 release. This PR updated deprecation annotations to reflect this. 
-- [#287] Deprecate `SyntheticEvent.isFormEvent`. Because form events do not exist as their own type in ReactJS, this helper will be removed in v6.0.0. Instead, check for the expected [form event types](https://reactjs.org/docs/events.html#form-events).  
+- [#289] Update most deprecations that were slated for removal in v6.0.0 to be slated for removal in v7.0.0 instead. To keep the migration to v6.0.0 as easy as possible, only APIs that are known to be completely unused will be removed in v6.0.0. Therefore, most APIs that were marked for removal in v6.0.0 will remain until the v7.0.0 release. This PR updated deprecation annotations to reflect this.
+- [#287] Deprecate `SyntheticEvent.isFormEvent`. Because form events do not exist as their own type in ReactJS, this helper will be removed in v6.0.0. Instead, check for the expected [form event types](https://reactjs.org/docs/events.html#form-events).
 
 ## [5.7.0](https://github.com/cleandart/react-dart/compare/5.6.1...5.7.0)
 
-- [#282] Add `SyntheticEvent` helpers that eliminate the need to use synthetic event class constructors. Additionally, added utilities to assist in type checking events without manually using the `is` keyword. 
+- [#282] Add `SyntheticEvent` helpers that eliminate the need to use synthetic event class constructors. Additionally, added utilities to assist in type checking events without manually using the `is` keyword.
 
 ## [5.6.1](https://github.com/cleandart/react-dart/compare/5.6.0...5.6.1)
 
-- [#280] Update React dev JS files to include a [workaround](https://github.com/dart-lang/sdk/issues/43193) to a DDC bug when using Chrome 86+ (fixed in Dart 2.9.3) 
+- [#280] Update React dev JS files to include a [workaround](https://github.com/dart-lang/sdk/issues/43193) to a DDC bug when using Chrome 86+ (fixed in Dart 2.9.3)
 
 ## [5.6.0](https://github.com/cleandart/react-dart/compare/5.5.1...5.6.0)
 
@@ -87,8 +94,8 @@ __New Features__
 
 - 🎉 🎉 🎉 __Support for function components, memo and hooks!!!__ 🎉 🎉 🎉
 
-    Sooooo much work from so many amazing people made this possible, but to summarize: 
-    
+    Sooooo much work from so many amazing people made this possible, but to summarize:
+
     - [#221] Add support for function components
     - [#252] Add support for `memo` higher order component
     - Hooks, hooks, and more hooks!
@@ -104,40 +111,40 @@ __New Features__
         - [#246] useDebugValue
 
     <p><br>It works like this...</p>
-    
+
     Define the component:
     ```dart
     import 'package:react/react.dart' as react;
-    
+
     final SomeWidget = react.registerFunctionComponent(_SomeWidget, displayName: 'SomeWidget');
-    
+
     _SomeWidget(Map props) {
       // You can use hooks in here, too!
-      
+
       return react.div({}, [
         // Some children...
       ]);
     }
     ```
-    
+
     Render the component _(exact same consumer API as a class-based component)_:
     ```dart
     import 'package:react/react_dom.dart' as react_dom;
     import 'some_widget.dart'; // Where your component is defined
-    
+
     main() {
       final renderedWidget = SomeWidget({
         // put some props here
       }, [
         // put some children here!
       ]);
-    
+
       react_dom.render(renderedWidget, querySelector('#idOfSomeNodeInTheDom'));
     }
     ```
-    
+
     > Check out all the [function component and hooks examples](https://github.com/cleandart/react-dart/blob/c9a1211d5d77a9e354b864e99ef8f52b60eeff85/example/test/function_component_test.dart) for more information!
-        
+
 __Fixes / Updates__
 - [#253] Deprecate `setClientConfiguration`.
     - It is no longer necessary - and can be removed from your implementations
@@ -147,7 +154,7 @@ __Fixes / Updates__
 
 __New Features__
 - [#244] Add support for [HTML Composition events](https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent)
-- [#263] Add support for [`SyntheticEvent.persist()`](https://reactjs.org/docs/events.html#event-pooling) 
+- [#263] Add support for [`SyntheticEvent.persist()`](https://reactjs.org/docs/events.html#event-pooling)
 
 __Fixes / Updates__
 - [#261] Stop errors thrown within the call stack of `Component.render()` from being swallowed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 6.1.8
+version: 6.2.0
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:


### PR DESCRIPTION
Pull Requests included in release:
* Patch changes:
	* [Raise analyzer minimum & unpin meta](https://github.com/Workiva/react-dart/pull/354)
	* [Pin mockito 5](https://github.com/Workiva/react-dart/pull/355)
	* [FED-1161 Unpin mockito, fix CI](https://github.com/Workiva/react-dart/pull/356)
* Minor changes:
	* [FED-1254 add Suspense component](https://github.com/Workiva/react-dart/pull/357)


Requested by: @kealjones-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/react-dart/compare/6.1.8...Workiva:release_react-dart_6.2.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/react-dart/compare/6.1.8...6.2.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4743698779471872/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4743698779471872/?repo_name=Workiva%2Freact-dart&pull_number=359)