### PR TITLE
RM-215032 Release react-dart 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@
 #### Potential behavior breakages
 - Component and Component2 members `props`/`state`/`jsThis` are late, will now throw instead of being null if accessed before initialized (e.g., in a constructor, final class field, or static lifecycle method).
 
+## [6.3.0](https://github.com/Workiva/react-dart/compare/6.2.1...6.3.0)
+- [#372], [#374] Add and update deprecations in preparation for 7.0.0 release, add WIP changelog
+- [#372] Add APIs in preparation for null safety:
+    - `htmlMain` - replacement for deprecated `react.main`, to be removed in 7.0.0
+    - `useRefInit` - `useRef` can't be used to create non-nullable-typed refs, but `useRefInit` can
+
 ## [6.2.1](https://github.com/Workiva/react-dart/compare/6.2.0...6.2.1)
 - [#366] Fix lints and eliminate most implicit casts 
 

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -486,6 +486,7 @@ class ReactClassConfig {
 /// Interop class for the data structure at `ReactElement._store`.
 ///
 /// Used to validate variadic children before they get to [React.createElement].
+@Deprecated('For internal use only. Will be made private in 7.0.0.')
 @JS()
 @anonymous
 class ReactElementStore {
@@ -681,6 +682,7 @@ class ReactDartContextInternal {
 }
 
 /// Creates a new JS Error object with the provided message.
+@Deprecated('For internal use only. Will be made private in 7.0.0.')
 @JS('Error')
 class JsError {
   external JsError(message);
@@ -706,6 +708,7 @@ external void throwErrorFromJS(error);
 /// as a variadic child.
 ///
 /// Offloaded to the JS to avoid dart2js interceptor lookup.
+@Deprecated('For internal use only. Will be made private in 7.0.0.')
 @JS('_markChildValidated')
 external void markChildValidated(child);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 6.2.1
+version: 6.3.0
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:


### PR DESCRIPTION
### Motivation
We need to release the changes merged to master, notably `htmlMain` so that consumers can support both react-dart 6.x and 7.x (once 7.x is released).

While removing APIs in the 7.0.0 WIP branch, I also noticed a few I missed that we should deprecate and remove in 7.0.0.

### Changes
- Update changelog and version meta for react-dart 6.3.0
- Deprecate ReactElementStore, JsError, markChildValidated

### Testing
CI passes