### PR TITLE
FED-1727 Remove the rest of the deprecated APIs for v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,12 @@
     - JsComponentConfig(2)
     - ReactDartInteropStatics
     - InteropContextValue
+    - markChildValidated
     - markChildrenValidated
+    - React.createFactory
+    - ReactElementStore
+    - ReactDartContextInternal
+    - JsError
 
 #### Other API breakages
 - `ReducerHook`, `StateHook`, and `Ref` are now `@sealed` and may not be inherited from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,19 @@
     - SyntheticEvent members `persist` and `isPersistent`
     - unconvertJsEventHandler 
 - APIs that were never intended for public use:
-    - JsPropValidator
-    - dartInteropStatics
     - ComponentStatics(2)
-    - createReactDartComponentClass(2)
-    - JsComponentConfig(2)
-    - ReactDartInteropStatics
     - InteropContextValue
+    - JsComponentConfig(2)
+    - JsError
+    - JsPropValidator
+    - React.createFactory
+    - ReactDartContextInternal
+    - ReactDartInteropStatics
+    - ReactElementStore
+    - createReactDartComponentClass(2)
+    - dartInteropStatics
     - markChildValidated
     - markChildrenValidated
-    - React.createFactory
-    - ReactElementStore
-    - ReactDartContextInternal
-    - JsError
 
 #### Other API breakages
 - `ReducerHook`, `StateHook`, and `Ref` are now `@sealed` and may not be inherited from

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -21,7 +21,7 @@ import 'package:react/src/react_client/private_utils.dart' show validateJsApi, v
 export 'package:react/src/context.dart';
 export 'package:react/src/prop_validator.dart';
 export 'package:react/src/react_client/event_helpers.dart';
-export 'package:react/react_client/react_interop.dart' show forwardRef2, createRef, memo, memo2;
+export 'package:react/react_client/react_interop.dart' show forwardRef2, createRef, memo2;
 export 'package:react/src/react_client/synthetic_event_wrappers.dart' hide NonNativeDataTransfer;
 export 'package:react/src/react_client/synthetic_data_transfer.dart' show SyntheticDataTransfer;
 export 'package:react/src/react_client/event_helpers.dart';

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -11,7 +11,6 @@ export 'package:react/react_client/component_factory.dart'
     show
         listifyChildren,
         unconvertJsProps,
-        unconvertJsEventHandler,
         ReactDomComponentFactoryProxy,
         ReactJsComponentFactoryProxy,
         ReactDartComponentFactoryProxy,

--- a/lib/react_client/bridge.dart
+++ b/lib/react_client/bridge.dart
@@ -1,8 +1,10 @@
+@JS()
+library react.react_client.bridge;
+
 import 'package:js/js.dart';
 import 'package:meta/meta.dart';
 import 'package:react/react.dart';
 import 'package:react/react_client/js_backed_map.dart';
-import 'package:react/react_client/react_interop.dart';
 import 'package:react/src/typedefs.dart';
 
 /// A function that returns a bridge instance for use with a given [component].
@@ -135,10 +137,15 @@ class Component2BridgeImpl extends Component2Bridge {
               location: location,
               propFullName: propFullName,
             ));
-        return error == null ? null : JsError(error.toString());
+        return error == null ? null : _JsError(error.toString());
       }
 
       return MapEntry(propKey, allowInterop(handlePropValidator));
     })).jsObject;
   }
+}
+
+@JS('Error')
+class _JsError {
+  external _JsError(message);
 }

--- a/lib/react_client/component_factory.dart
+++ b/lib/react_client/component_factory.dart
@@ -14,7 +14,7 @@ import 'package:react/src/js_interop_util.dart';
 import 'package:react/src/react_client/factory_util.dart';
 
 // ignore: deprecated_member_use_from_same_package
-export 'package:react/src/react_client/factory_util.dart' show generateJsProps, unconvertJsEventHandler;
+export 'package:react/src/react_client/factory_util.dart' show generateJsProps;
 
 /// Prepares [children] to be passed to the ReactJS [React.createElement] and
 /// the Dart [Component2].

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -422,17 +422,6 @@ class ReactClassConfig {
   external set displayName(String value);
 }
 
-/// Interop class for the data structure at `ReactElement._store`.
-///
-/// Used to validate variadic children before they get to [React.createElement].
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-@JS()
-@anonymous
-class ReactElementStore {
-  external bool get validated;
-  external set validated(bool value);
-}
-
 /// A virtual DOM element representing an instance of a DOM element,
 /// React component, or fragment.
 ///
@@ -453,8 +442,6 @@ class ReactElementStore {
 @JS()
 @anonymous
 class ReactElement {
-  external ReactElementStore get _store; // ignore: unused_element
-
   /// The type of this element.
   ///
   /// For DOM components, this will be a [String] tagName (e.g., `'div'`, `'a'`).
@@ -581,13 +568,6 @@ class ReactDartComponentInternal {
   final Map props;
 }
 
-/// Creates a new JS Error object with the provided message.
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-@JS('Error')
-class JsError {
-  external JsError(message);
-}
-
 /// A JS variable that can be used with Dart interop in order to force returning a JavaScript `null`.
 /// Use this if dart2js is possibly converting Dart `null` into `undefined`.
 @JS('_jsNull')
@@ -602,14 +582,6 @@ external get jsUndefined;
 /// This allows us to catch the error in dart which re-dartifies the js errors/exceptions.
 @JS('_throwErrorFromJS')
 external Never throwErrorFromJS(error);
-
-/// Marks [child] as validated, as if it were passed into [React.createElement]
-/// as a variadic child.
-///
-/// Offloaded to the JS to avoid dart2js interceptor lookup.
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-@JS('_markChildValidated')
-external void markChildValidated(child);
 
 @JS('React.__isDevelopment')
 external bool get _inReactDevMode;

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -14,10 +14,8 @@ import 'package:js/js_util.dart';
 import 'package:meta/meta.dart';
 import 'package:react/hooks.dart';
 import 'package:react/react.dart';
-import 'package:react/react_client/bridge.dart';
 import 'package:react/react_client/js_backed_map.dart';
-import 'package:react/react_client/component_factory.dart'
-    show ReactDartWrappedComponentFactoryProxy, ReactDartFunctionComponentFactoryProxy, ReactJsComponentFactoryProxy;
+import 'package:react/react_client/component_factory.dart' show ReactDartWrappedComponentFactoryProxy;
 import 'package:react/src/react_client/dart2_interop_workaround_bindings.dart';
 
 typedef ReactJsComponentFactory = ReactElement Function(dynamic props, dynamic children);
@@ -518,26 +516,6 @@ class ReactComponent {
 //   Interop internals
 // ----------------------------------------------------------------------------
 
-/// A JavaScript interop class representing a value in a React JS `context` object.
-///
-/// Used for storing/accessing Dart [ReactDartContextInternal] objects in `context`
-/// in a way that's opaque to the JS, and avoids the need to use dart2js interceptors.
-///
-/// __For internal/advanced use only.__
-///
-/// > __DEPRECATED - DO NOT USE__
-/// >
-/// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
-/// > in ReactJS 16.
-/// >
-/// > This will be completely removed alongside the Component class.
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-@JS()
-@anonymous
-class InteropContextValue {
-  external factory InteropContextValue();
-}
-
 /// A JavaScript interop class representing the return value of `createContext`.
 ///
 /// Used for accessing Dart [Context.Provider] & [Context.Consumer] components.
@@ -602,24 +580,6 @@ class ReactDartComponentInternal {
   final Map props;
 }
 
-/// Internal react-dart information used to proxy React JS lifecycle to Dart
-/// [Component] instances.
-///
-/// __For internal/advanced use only.__
-///
-/// > __DEPRECATED - DO NOT USE__
-/// >
-/// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
-/// > in ReactJS 16.
-/// >
-/// > This will be completely removed alongside the Component class.
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-class ReactDartContextInternal {
-  final dynamic value;
-
-  ReactDartContextInternal(this.value);
-}
-
 /// Creates a new JS Error object with the provided message.
 @JS('Error')
 class JsError {
@@ -648,38 +608,6 @@ external Never throwErrorFromJS(error);
 @JS('_markChildValidated')
 external void markChildValidated(child);
 
-/// Mark each child in [children] as validated so that React doesn't emit key warnings.
-///
-/// ___Only for use with variadic children.___
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-void markChildrenValidated(List<dynamic> children) {
-  for (final child in children) {
-    // Use `isValidElement` since `is ReactElement` doesn't behave as expected.
-    if (React.isValidElement(child)) {
-      markChildValidated(child);
-    }
-  }
-}
-
-/// Returns a new JS [ReactClass] for a component that uses
-/// [dartInteropStatics] and [componentStatics] internally to proxy between
-/// the JS and Dart component instances.
-@JS('_createReactDartComponentClass')
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-external ReactClass createReactDartComponentClass(
-    ReactDartInteropStatics dartInteropStatics, ComponentStatics componentStatics,
-    [JsComponentConfig? jsConfig]);
-
-/// Returns a new JS [ReactClass] for a component that uses
-/// [dartInteropStatics] and [componentStatics] internally to proxy between
-/// the JS and Dart component instances.
-///
-/// See `_ReactDartInteropStatics2.staticsForJs`]` for an example implementation.
-@JS('_createReactDartComponentClass2')
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-external ReactClass createReactDartComponentClass2(JsMap dartInteropStatics, ComponentStatics2 componentStatics,
-    [JsComponentConfig2? jsConfig]);
-
 @JS('React.__isDevelopment')
 external bool get _inReactDevMode;
 
@@ -694,101 +622,6 @@ external bool get _inReactDevMode;
 /// > This value will be `true` if your HTML page includes `react.js` or `react_with_addons.js`,
 ///   and `false` if your HTML page includes `react_prod.js` or `react_with_react_dom_prod.js`.
 bool get inReactDevMode => _inReactDevMode;
-
-/// An object that stores static methods used by all Dart components.
-@JS()
-@anonymous
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-class ReactDartInteropStatics {
-  external factory ReactDartInteropStatics({
-    Component Function(
-      ReactComponent jsThis,
-      ReactDartComponentInternal internal,
-      InteropContextValue context,
-      ComponentStatics componentStatics,
-    )
-        initComponent,
-    InteropContextValue Function(Component component) handleGetChildContext,
-    void Function(Component component) handleComponentWillMount,
-    void Function(Component component) handleComponentDidMount,
-    void Function(
-      Component component,
-      ReactDartComponentInternal nextInternal,
-      InteropContextValue nextContext,
-    )
-        handleComponentWillReceiveProps,
-    bool Function(Component component, InteropContextValue nextContext) handleShouldComponentUpdate,
-    void Function(Component component, InteropContextValue nextContext) handleComponentWillUpdate,
-    void Function(Component component, ReactDartComponentInternal prevInternal) handleComponentDidUpdate,
-    void Function(Component component) handleComponentWillUnmount,
-    dynamic Function(Component component) handleRender,
-  });
-}
-
-/// An object that stores static methods and information for a specific component class.
-///
-/// This object is made accessible to a component's JS ReactClass config, which
-/// passes it to certain methods in [ReactDartInteropStatics].
-///
-/// See [ReactDartInteropStatics], [createReactDartComponentClass].
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-class ComponentStatics {
-  final ComponentFactory<Component> componentFactory;
-  ComponentStatics(this.componentFactory);
-}
-
-/// An object that stores static methods and information for a specific component class.
-///
-/// This object is made accessible to a component's JS ReactClass config, which
-/// passes it to certain methods in `ReactDartInteropStatics2`.
-///
-/// See `ReactDartInteropStatics2`, [createReactDartComponentClass2].
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-class ComponentStatics2 {
-  final ComponentFactory<Component2> componentFactory;
-  final Component2 instanceForStaticMethods;
-  final Component2BridgeFactory bridgeFactory;
-
-  ComponentStatics2({
-    required this.componentFactory,
-    required this.instanceForStaticMethods,
-    required this.bridgeFactory,
-  });
-}
-
-/// Additional configuration passed to [createReactDartComponentClass]
-/// that needs to be directly accessible by that JS code.
-///
-/// > __DEPRECATED - DO NOT USE__
-/// >
-/// > The `context` API that this supports was never stable in any version of ReactJS,
-/// > and was replaced with a new, incompatible context API in ReactJS 16 that is exposed
-/// > via the [Component2] class and is supported by [JsComponentConfig2].
-/// >
-/// > This will be completely removed alongside the Component class.
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-@JS()
-@anonymous
-class JsComponentConfig {
-  external factory JsComponentConfig({
-    Iterable<String>? childContextKeys,
-    Iterable<String>? contextKeys,
-  });
-}
-
-/// Additional configuration passed to [createReactDartComponentClass2]
-/// that needs to be directly accessible by that JS code.
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-@JS()
-@anonymous
-class JsComponentConfig2 {
-  external factory JsComponentConfig2({
-    required List<String> skipMethods,
-    dynamic contextType,
-    JsMap defaultProps,
-    JsMap propTypes,
-  });
-}
 
 /// Information on an error caught by `componentDidCatch`.
 @JS()

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -21,9 +21,6 @@ import 'package:react/react_client/component_factory.dart'
 import 'package:react/src/react_client/dart2_interop_workaround_bindings.dart';
 
 typedef ReactJsComponentFactory = ReactElement Function(dynamic props, dynamic children);
-@Deprecated('For internal use only. Will be made private in 7.0.0.')
-typedef JsPropValidator = dynamic Function(
-    JsMap props, String propName, String componentName, String location, String propFullName, String secret);
 
 // ----------------------------------------------------------------------------
 //   Top-level API
@@ -39,8 +36,6 @@ abstract class React {
   ]);
   @Deprecated('For internal use only.')
   external static ReactClass createClass(ReactClassConfig reactClassConfig);
-  @Deprecated('Use createElement instead. To be removed in 7.0.0.')
-  external static ReactJsComponentFactory createFactory(type);
   external static ReactElement createElement(dynamic type, props, [Object? children]);
   external static JsRef createRef();
   external static ReactClass forwardRef(Function(JsMap props, dynamic ref) wrapperFunction);
@@ -278,22 +273,6 @@ ReactComponentFactoryProxy memo2(ReactComponentFactoryProxy factory,
   setProperty(hoc, 'dartComponentVersion', ReactDartComponentVersion.component2);
 
   return ReactDartWrappedComponentFactoryProxy(hoc);
-}
-
-@Deprecated('Use memo2')
-ReactJsComponentFactoryProxy memo(ReactDartFunctionComponentFactoryProxy factory,
-    {bool Function(Map prevProps, Map nextProps)? areEqual}) {
-  final _areEqual = areEqual == null
-      ? null
-      : allowInterop((JsMap prevProps, JsMap nextProps) {
-          final dartPrevProps = JsBackedMap.backedBy(prevProps);
-          final dartNextProps = JsBackedMap.backedBy(nextProps);
-          return areEqual(dartPrevProps, dartNextProps);
-        });
-  final hoc = React.memo(factory.type, _areEqual);
-  setProperty(hoc, 'dartComponentVersion', ReactDartComponentVersion.component2);
-
-  return ReactJsComponentFactoryProxy(hoc, alwaysReturnChildrenAsList: true);
 }
 
 abstract class ReactDom {

--- a/lib/src/react_client/component_registration.dart
+++ b/lib/src/react_client/component_registration.dart
@@ -7,6 +7,7 @@ import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_client/component_factory.dart';
 
 import 'package:react/src/react_client/dart_interop_statics.dart';
+import 'package:react/src/react_client/internal_react_interop.dart';
 
 import '../js_interop_util.dart';
 

--- a/lib/src/react_client/dart_interop_statics.dart
+++ b/lib/src/react_client/dart_interop_statics.dart
@@ -11,6 +11,7 @@ import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_client/zone.dart';
+import 'package:react/src/react_client/internal_react_interop.dart';
 
 import 'package:react/src/react_client/private_utils.dart';
 import 'package:react/src/typedefs.dart';

--- a/lib/src/react_client/event_helpers.dart
+++ b/lib/src/react_client/event_helpers.dart
@@ -767,12 +767,6 @@ extension SyntheticEventTypeHelpers on SyntheticEvent {
   bool _checkEventType(List<String> types) => getProperty(this, 'type') != null && types.any((t) => type.contains(t));
   bool _hasProperty(String propertyName) => hasProperty(this, propertyName);
 
-  /// Whether the event instance has been removed from the ReactJS event pool.
-  ///
-  /// > See: [persist]
-  @Deprecated('The modern event system does not use pooling. This always returns true, and will be removed.')
-  bool get isPersistent => true;
-
   /// Uses Duck Typing to detect if the event instance is a [SyntheticClipboardEvent].
   bool get isClipboardEvent => _hasProperty('clipboardData') || _checkEventType(const ['copy', 'paste', 'cut']);
 

--- a/lib/src/react_client/factory_util.dart
+++ b/lib/src/react_client/factory_util.dart
@@ -26,9 +26,6 @@ dynamic convertArgsToChildren(List childrenArgs) {
   }
 }
 
-@Deprecated('This is no longer necessary since event handlers are no longer converted.')
-Function? unconvertJsEventHandler(Function jsConvertedEventHandler) => null;
-
 void convertRefValue(Map args) {
   final ref = args['ref'];
   if (ref is Ref) {

--- a/lib/src/react_client/factory_util.dart
+++ b/lib/src/react_client/factory_util.dart
@@ -7,6 +7,7 @@ import 'package:react/react_client/component_factory.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/react_interop.dart';
+import 'package:react/src/react_client/internal_react_interop.dart';
 
 /// Converts a list of variadic children arguments to children that should be passed to ReactJS.
 ///

--- a/lib/src/react_client/internal_react_interop.dart
+++ b/lib/src/react_client/internal_react_interop.dart
@@ -10,7 +10,7 @@ import 'package:react/react.dart' show Component, Component2, ComponentFactory;
 import 'package:react/react_client/bridge.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/react_interop.dart'
-    show React, ReactClass, ReactComponent, ReactDartComponentInternal, markChildValidated;
+    show React, ReactClass, ReactComponent, ReactDartComponentInternal;
 
 /// A JavaScript interop class representing a value in a React JS `context` object.
 ///
@@ -49,6 +49,14 @@ class ReactDartContextInternal {
 
   ReactDartContextInternal(this.value);
 }
+
+/// Marks [child] as validated, as if it were passed into [React.createElement]
+/// as a variadic child.
+///
+/// Offloaded to the JS to avoid dart2js interceptor lookup.
+@JS('_markChildValidated')
+@internal
+external void markChildValidated(child);
 
 /// Mark each child in [children] as validated so that React doesn't emit key warnings.
 ///

--- a/lib/src/react_client/internal_react_interop.dart
+++ b/lib/src/react_client/internal_react_interop.dart
@@ -1,0 +1,178 @@
+/// Internal react-dart JS interop bindings and utilities.
+@JS()
+library react.src.react_client.internal_react_interop;
+
+// ignore_for_file: deprecated_member_use_from_same_package
+
+import 'package:js/js.dart';
+import 'package:meta/meta.dart';
+import 'package:react/react.dart' show Component, Component2, ComponentFactory;
+import 'package:react/react_client/bridge.dart';
+import 'package:react/react_client/js_backed_map.dart';
+import 'package:react/react_client/react_interop.dart'
+    show React, ReactClass, ReactComponent, ReactDartComponentInternal, markChildValidated;
+
+/// A JavaScript interop class representing a value in a React JS `context` object.
+///
+/// Used for storing/accessing Dart [ReactDartContextInternal] objects in `context`
+/// in a way that's opaque to the JS, and avoids the need to use dart2js interceptors.
+///
+/// __For internal/advanced use only.__
+///
+/// > __DEPRECATED - DO NOT USE__
+/// >
+/// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+/// > in ReactJS 16.
+/// >
+/// > This will be completely removed alongside the Component class.
+@internal
+@JS()
+@anonymous
+class InteropContextValue {
+  external factory InteropContextValue();
+}
+
+/// Internal react-dart information used to proxy React JS lifecycle to Dart
+/// [Component] instances.
+///
+/// __For internal/advanced use only.__
+///
+/// > __DEPRECATED - DO NOT USE__
+/// >
+/// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+/// > in ReactJS 16.
+/// >
+/// > This will be completely removed alongside the Component class.
+@internal
+class ReactDartContextInternal {
+  final dynamic value;
+
+  ReactDartContextInternal(this.value);
+}
+
+/// Mark each child in [children] as validated so that React doesn't emit key warnings.
+///
+/// ___Only for use with variadic children.___
+@internal
+void markChildrenValidated(List<dynamic> children) {
+  for (final child in children) {
+    // Use `isValidElement` since `is ReactElement` doesn't behave as expected.
+    if (React.isValidElement(child)) {
+      markChildValidated(child);
+    }
+  }
+}
+
+/// Returns a new JS [ReactClass] for a component that uses
+/// [dartInteropStatics] and [componentStatics] internally to proxy between
+/// the JS and Dart component instances.
+@JS('_createReactDartComponentClass')
+@internal
+external ReactClass createReactDartComponentClass(
+    ReactDartInteropStatics dartInteropStatics, ComponentStatics componentStatics,
+    [JsComponentConfig? jsConfig]);
+
+/// Returns a new JS [ReactClass] for a component that uses
+/// [dartInteropStatics] and [componentStatics] internally to proxy between
+/// the JS and Dart component instances.
+///
+/// See `_ReactDartInteropStatics2.staticsForJs`]` for an example implementation.
+@JS('_createReactDartComponentClass2')
+@internal
+external ReactClass createReactDartComponentClass2(JsMap dartInteropStatics, ComponentStatics2 componentStatics,
+    [JsComponentConfig2? jsConfig]);
+
+/// An object that stores static methods used by all Dart components.
+@JS()
+@anonymous
+@internal
+class ReactDartInteropStatics {
+  external factory ReactDartInteropStatics({
+    Component Function(
+      ReactComponent jsThis,
+      ReactDartComponentInternal internal,
+      InteropContextValue context,
+      ComponentStatics componentStatics,
+    )
+        initComponent,
+    InteropContextValue Function(Component component) handleGetChildContext,
+    void Function(Component component) handleComponentWillMount,
+    void Function(Component component) handleComponentDidMount,
+    void Function(
+      Component component,
+      ReactDartComponentInternal nextInternal,
+      InteropContextValue nextContext,
+    )
+        handleComponentWillReceiveProps,
+    bool Function(Component component, InteropContextValue nextContext) handleShouldComponentUpdate,
+    void Function(Component component, InteropContextValue nextContext) handleComponentWillUpdate,
+    void Function(Component component, ReactDartComponentInternal prevInternal) handleComponentDidUpdate,
+    void Function(Component component) handleComponentWillUnmount,
+    dynamic Function(Component component) handleRender,
+  });
+}
+
+/// An object that stores static methods and information for a specific component class.
+///
+/// This object is made accessible to a component's JS ReactClass config, which
+/// passes it to certain methods in [ReactDartInteropStatics].
+///
+/// See [ReactDartInteropStatics], [createReactDartComponentClass].
+@internal
+class ComponentStatics {
+  final ComponentFactory<Component> componentFactory;
+  ComponentStatics(this.componentFactory);
+}
+
+/// An object that stores static methods and information for a specific component class.
+///
+/// This object is made accessible to a component's JS ReactClass config, which
+/// passes it to certain methods in `ReactDartInteropStatics2`.
+///
+/// See `ReactDartInteropStatics2`, [createReactDartComponentClass2].
+@internal
+class ComponentStatics2 {
+  final ComponentFactory<Component2> componentFactory;
+  final Component2 instanceForStaticMethods;
+  final Component2BridgeFactory bridgeFactory;
+
+  ComponentStatics2({
+    required this.componentFactory,
+    required this.instanceForStaticMethods,
+    required this.bridgeFactory,
+  });
+}
+
+/// Additional configuration passed to [createReactDartComponentClass]
+/// that needs to be directly accessible by that JS code.
+///
+/// > __DEPRECATED - DO NOT USE__
+/// >
+/// > The `context` API that this supports was never stable in any version of ReactJS,
+/// > and was replaced with a new, incompatible context API in ReactJS 16 that is exposed
+/// > via the [Component2] class and is supported by [JsComponentConfig2].
+/// >
+/// > This will be completely removed alongside the Component class.
+@internal
+@JS()
+@anonymous
+class JsComponentConfig {
+  external factory JsComponentConfig({
+    Iterable<String>? childContextKeys,
+    Iterable<String>? contextKeys,
+  });
+}
+
+/// Additional configuration passed to [createReactDartComponentClass2]
+/// that needs to be directly accessible by that JS code.
+@internal
+@JS()
+@anonymous
+class JsComponentConfig2 {
+  external factory JsComponentConfig2({
+    required List<String> skipMethods,
+    dynamic contextType,
+    JsMap defaultProps,
+    JsMap propTypes,
+  });
+}

--- a/lib/src/react_client/private_utils.dart
+++ b/lib/src/react_client/private_utils.dart
@@ -8,6 +8,7 @@ import 'package:react/react.dart' show Component2;
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/src/js_interop_util.dart';
 import 'package:react/src/react_client/component_registration.dart' show registerComponent2;
+import 'package:react/src/react_client/internal_react_interop.dart';
 
 /// A flag used to cache whether React is accessible.
 ///

--- a/lib/src/react_client/synthetic_event_wrappers.dart
+++ b/lib/src/react_client/synthetic_event_wrappers.dart
@@ -103,47 +103,6 @@ class SyntheticEvent {
   ///
   /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault>
   external void preventDefault();
-
-  /// Call this method on the current event instance if you want to access the event properties in an asynchronous way.
-  ///
-  /// This will remove the synthetic event from the event pool and allow references
-  /// to the event to be retained by user code.
-  ///
-  /// For example, `setState` callbacks are fired after a component updates as a result of the
-  /// new state being passed in - and since component updates are not guaranteed to by synchronous, any
-  /// reference to a `SyntheticEvent` within that callback could have been recycled by ReactJS internals.
-  ///
-  /// You can use `persist()` to ensure access to the event properties within the callback as shown in
-  /// the second example below.
-  ///
-  /// __Without persist()__
-  /// ```dart
-  /// void handleClick(SyntheticMouseEvent event) {
-  ///   print(event.type); // => "click"
-  ///
-  ///   setState({}, () {
-  ///     print(event.type); // => null
-  ///     print(event.isPersistent); => false
-  ///   });
-  /// }
-  /// ```
-  ///
-  /// __With persist()__
-  /// ```dart
-  /// void handleClick(SyntheticMouseEvent event) {
-  ///   print(event.type); // => "click"
-  ///   event.persist();
-  ///
-  ///   setState({}, () {
-  ///     print(event.type); // => "click"
-  ///     print(event.isPersistent); => true
-  ///   });
-  /// }
-  /// ```
-  ///
-  /// See: <https://reactjs.org/docs/events.html#event-pooling>
-  @Deprecated('The modern event system does not use pooling. This does nothing.')
-  external void persist();
 }
 
 /// A [SyntheticEvent] wrapper that is specifically backed by a [ClipboardEvent].

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -294,20 +294,6 @@ void domEventHandlerWrappingTests(ReactComponentFactoryProxy factory) {
     }
   });
 
-  test('event has .persist and .isPersistent methods that can be called', () {
-    late react.SyntheticMouseEvent actualEvent;
-
-    final nodeWithClickHandler = renderAndGetRootNode(factory({
-      'onClick': (react.SyntheticMouseEvent event) {
-        expect(() => event.persist(), returnsNormally);
-        actualEvent = event;
-      }
-    }));
-
-    rtu.Simulate.click(nodeWithClickHandler);
-    expect(actualEvent.isPersistent, isA<bool>());
-  });
-
   test('doesn\'t wrap the handler if it is null', () {
     final nodeWithClickHandler = renderAndGetRootNode(factory({'onClick': null}));
 

--- a/test/js_builds/shared_tests.dart
+++ b/test/js_builds/shared_tests.dart
@@ -10,6 +10,7 @@ import 'package:react/react.dart' as react;
 import 'package:react/react_client/component_factory.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client/react_interop.dart';
+import 'package:react/src/react_client/internal_react_interop.dart';
 import 'package:test/test.dart';
 
 void verifyJsFileLoaded(String filename) {

--- a/test/js_builds/shared_tests.dart
+++ b/test/js_builds/shared_tests.dart
@@ -7,6 +7,7 @@ import 'dart:js_util';
 
 import 'package:js/js.dart';
 import 'package:react/react.dart' as react;
+import 'package:react/react_client/component_factory.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client/react_interop.dart';
 import 'package:test/test.dart';
@@ -172,7 +173,7 @@ void sharedErrorBoundaryComponentNameTests() {
 
     test('Component components', () {
       expectRenderErrorWithComponentName(
-        _ThrowingComponent({}) as ReactElement,
+        _ThrowingComponent({}),
         expectedComponentName: r'DisplayName$_ThrowingComponent',
       );
     });
@@ -220,7 +221,8 @@ class _ErrorBoundaryComponent extends react.Component2 {
   }
 }
 
-final _ThrowingComponent = react.registerComponent(() => _ThrowingComponentComponent());
+final _ThrowingComponent =
+    react.registerComponent(() => _ThrowingComponentComponent()) as ReactDartComponentFactoryProxy;
 
 class _ThrowingComponentComponent extends react.Component {
   @override

--- a/test/react_memo_test.dart
+++ b/test/react_memo_test.dart
@@ -12,28 +12,6 @@ import 'package:test/test.dart';
 import 'factory/common_factory_tests.dart';
 
 main() {
-  group('memo', () {
-    // ignore: deprecated_member_use_from_same_package
-    sharedMemoTests(react.memo);
-
-    group('- common factory behavior -', () {
-      // ignore: deprecated_member_use_from_same_package
-      final MemoTest = react.memo(react.registerFunctionComponent((props) {
-        props['onDartRender']?.call(props);
-        return react.div({...props});
-      }));
-
-      commonFactoryTests(
-        MemoTest,
-        // ignore: invalid_use_of_protected_member
-        dartComponentVersion: ReactDartComponentVersion.component2,
-        // Dart props passed to memo get converted when they shouldn't, so these tests fail.
-        // This is part of why memo is deprecated.
-        skipPropValuesTest: true,
-      );
-    });
-  });
-
   group('memo2', () {
     sharedMemoTests(react.memo2);
 


### PR DESCRIPTION
# Dependent PR
This PR is dependent on https://github.com/Workiva/react-dart/pull/373. I've made this PR into the null safety branch so that this is a clean diff, and we'll want to merge that PR first before this one.

## Motivation
There are some APIs we've planned on removing in 7.0.0, and it's time to remove them. 

Some APIs have already been removed in the v7_wip branch, and this PR should remove the rest of them.

Notably, there were quite a few APIs that aren't being removed outright, but instead are being made private.

## Solution
- lib/react_client/react_interop.dart
    - Remove unused, deprecated APIs
        - JsPropValidator
        - `ReactElementStore` 
        - `React.createFactory`
    - Make deprecated APIs private (mostly moved to a new lib/src/react_client/internal_react_interop.dart):
      - InteropContextValue
      - ReactDartContextInternal
      - markChildValidated
      - markChildrenValidated
      - createReactDartComponentClass
      - createReactDartComponentClass2
      - ReactDartInteropStatics
      - ComponentStatics
      - ComponentStatics2
      - JsComponentConfig
      - JsComponentConfig2
- Remove deprecated APIs in other libraries
    - SyntheticEvent members `persist` and `isPersistent`
    - `memo`

## Testing
- Only deprecated APIs were removed
- CI passes
- Semver audit diff looks good: https://gist.github.com/greglittlefield-wf/7a41f38a3759441cfbef4e1b93a051b9

We'll do another semver audit of API changes from other PRs when we go to merge v7_wip, so no additional testing is needed at this time.