### PR TITLE
FED-1850 Add Dart 2.19 to GHA matrix

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         # Can't run on `stable` (Dart 3) until we're fully null-safe.
-        sdk: [2.18.7]
+        sdk: [2.18.7, 2.19.6]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
## Motivation
We're only running GitHub Actions in 2.18, and not 2.19 (the latest minor of Dart 2).

## Solution
Add 2.19.6 to the GitHub Actions matrix.

## Testing
CI passes, including new 2.19.6 run.