### PR TITLE
FED-1881 Fix regression in SyntheticEvent mock class type-checking

### DIFF
--- a/test/mockito.dart
+++ b/test/mockito.dart
@@ -5,10 +5,12 @@ library react.test.mockito_gen_entrypoint;
 
 import 'dart:html';
 import 'package:mockito/annotations.dart';
+import 'package:react/src/react_client/synthetic_event_wrappers.dart';
 
 @GenerateNiceMocks([
   MockSpec<KeyboardEvent>(),
   MockSpec<DataTransfer>(),
   MockSpec<MouseEvent>(),
+  MockSpec<SyntheticMouseEvent>(),
 ])
 main() {}

--- a/test/mockito.dart
+++ b/test/mockito.dart
@@ -11,6 +11,6 @@ import 'package:react/src/react_client/synthetic_event_wrappers.dart';
   MockSpec<KeyboardEvent>(),
   MockSpec<DataTransfer>(),
   MockSpec<MouseEvent>(),
-  MockSpec<SyntheticMouseEvent>(),
+  MockSpec<SyntheticEvent>(),
 ])
 main() {}

--- a/test/mockito.mocks.dart
+++ b/test/mockito.mocks.dart
@@ -446,83 +446,10 @@ class MockMouseEvent extends _i1.Mock implements _i2.MouseEvent {
       );
 }
 
-/// A class which mocks [SyntheticMouseEvent].
+/// A class which mocks [SyntheticEvent].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSyntheticMouseEvent extends _i1.Mock
-    implements _i4.SyntheticMouseEvent {
-  @override
-  bool get altKey => (super.noSuchMethod(
-        Invocation.getter(#altKey),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-  @override
-  num get button => (super.noSuchMethod(
-        Invocation.getter(#button),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as num);
-  @override
-  num get buttons => (super.noSuchMethod(
-        Invocation.getter(#buttons),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as num);
-  @override
-  num get clientX => (super.noSuchMethod(
-        Invocation.getter(#clientX),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as num);
-  @override
-  num get clientY => (super.noSuchMethod(
-        Invocation.getter(#clientY),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as num);
-  @override
-  bool get ctrlKey => (super.noSuchMethod(
-        Invocation.getter(#ctrlKey),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-  @override
-  bool get metaKey => (super.noSuchMethod(
-        Invocation.getter(#metaKey),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-  @override
-  num get pageX => (super.noSuchMethod(
-        Invocation.getter(#pageX),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as num);
-  @override
-  num get pageY => (super.noSuchMethod(
-        Invocation.getter(#pageY),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as num);
-  @override
-  num get screenX => (super.noSuchMethod(
-        Invocation.getter(#screenX),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as num);
-  @override
-  num get screenY => (super.noSuchMethod(
-        Invocation.getter(#screenY),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as num);
-  @override
-  bool get shiftKey => (super.noSuchMethod(
-        Invocation.getter(#shiftKey),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+class MockSyntheticEvent extends _i1.Mock implements _i4.SyntheticEvent {
   @override
   bool get bubbles => (super.noSuchMethod(
         Invocation.getter(#bubbles),

--- a/test/mockito.mocks.dart
+++ b/test/mockito.mocks.dart
@@ -7,6 +7,7 @@ import 'dart:html' as _i2;
 import 'dart:math' as _i3;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:react/src/react_client/synthetic_event_wrappers.dart' as _i4;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -439,6 +440,135 @@ class MockMouseEvent extends _i1.Mock implements _i2.MouseEvent {
   void stopPropagation() => super.noSuchMethod(
         Invocation.method(
           #stopPropagation,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
+/// A class which mocks [SyntheticMouseEvent].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockSyntheticMouseEvent extends _i1.Mock
+    implements _i4.SyntheticMouseEvent {
+  @override
+  bool get altKey => (super.noSuchMethod(
+        Invocation.getter(#altKey),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+  @override
+  num get button => (super.noSuchMethod(
+        Invocation.getter(#button),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as num);
+  @override
+  num get buttons => (super.noSuchMethod(
+        Invocation.getter(#buttons),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as num);
+  @override
+  num get clientX => (super.noSuchMethod(
+        Invocation.getter(#clientX),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as num);
+  @override
+  num get clientY => (super.noSuchMethod(
+        Invocation.getter(#clientY),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as num);
+  @override
+  bool get ctrlKey => (super.noSuchMethod(
+        Invocation.getter(#ctrlKey),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+  @override
+  bool get metaKey => (super.noSuchMethod(
+        Invocation.getter(#metaKey),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+  @override
+  num get pageX => (super.noSuchMethod(
+        Invocation.getter(#pageX),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as num);
+  @override
+  num get pageY => (super.noSuchMethod(
+        Invocation.getter(#pageY),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as num);
+  @override
+  num get screenX => (super.noSuchMethod(
+        Invocation.getter(#screenX),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as num);
+  @override
+  num get screenY => (super.noSuchMethod(
+        Invocation.getter(#screenY),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as num);
+  @override
+  bool get shiftKey => (super.noSuchMethod(
+        Invocation.getter(#shiftKey),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+  @override
+  bool get bubbles => (super.noSuchMethod(
+        Invocation.getter(#bubbles),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+  @override
+  bool get cancelable => (super.noSuchMethod(
+        Invocation.getter(#cancelable),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+  @override
+  bool get defaultPrevented => (super.noSuchMethod(
+        Invocation.getter(#defaultPrevented),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+  @override
+  num get eventPhase => (super.noSuchMethod(
+        Invocation.getter(#eventPhase),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as num);
+  @override
+  bool get isTrusted => (super.noSuchMethod(
+        Invocation.getter(#isTrusted),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+  @override
+  num get timeStamp => (super.noSuchMethod(
+        Invocation.getter(#timeStamp),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as num);
+  @override
+  String get type => (super.noSuchMethod(
+        Invocation.getter(#type),
+        returnValue: '',
+        returnValueForMissingStub: '',
+      ) as String);
+  @override
+  void preventDefault() => super.noSuchMethod(
+        Invocation.method(
+          #preventDefault,
           [],
         ),
         returnValueForMissingStub: null,

--- a/test/react_client/event_helpers_test.dart
+++ b/test/react_client/event_helpers_test.dart
@@ -1703,6 +1703,10 @@ main() {
               () {
             expect(eventTypeTester(newObject() as SyntheticEvent), isFalse);
           });
+
+          test('when the argument is a mocked event object with no mocked `type` property, and does not throw', () {
+            expect(eventTypeTester(MockSyntheticMouseEvent()), isFalse);
+          });
         });
       }
 
@@ -1989,6 +1993,14 @@ main() {
             commonFalseTests((e) => e.isWheelEvent, SyntheticEventType.syntheticWheelEvent);
           });
         });
+      });
+
+      // Regression test for Mock class behavior consumers rely on.
+      test('checks types correctly for Mock objects with `type` mocked', () {
+        final mockEvent = MockSyntheticMouseEvent();
+        when(mockEvent.type).thenReturn('click');
+        expect(mockEvent.isMouseEvent, isTrue);
+        expect(mockEvent.isKeyboardEvent, false);
       });
     });
 

--- a/test/react_client/event_helpers_test.dart
+++ b/test/react_client/event_helpers_test.dart
@@ -1705,7 +1705,15 @@ main() {
           });
 
           test('when the argument is a mocked event object with no mocked `type` property, and does not throw', () {
-            expect(eventTypeTester(MockSyntheticMouseEvent()), isFalse);
+            // Typically consumers would mock a specific SyntheticEvent subtype, but creating null-safe mocks for those
+            // causes property checks like `_hasProperty('button')` in helper methods to return true in DDC
+            // (e.g., `.isMouseEvent` for a `MockSyntheticMouseEvent` would return true).
+            //
+            // We really just want to check the `type` behavior here, especially for non-null-safe mocks, so we'll use
+            // the generic MockSyntheticEvent.
+            //
+            // *See other test with similar note to this one.*
+            expect(eventTypeTester(MockSyntheticEvent()), isFalse);
           });
         });
       }
@@ -1996,8 +2004,17 @@ main() {
       });
 
       // Regression test for Mock class behavior consumers rely on.
+      //
+      // Typically consumers would mock a specific SyntheticEvent subtype, but creating null-safe mocks for those
+      // causes property checks like `_hasProperty('button')` in helper methods to return true in DDC
+      // (e.g., `.isMouseEvent` for a `MockSyntheticMouseEvent` would return true).
+      //
+      // We really just want to check the `type` behavior here, especially for non-null-safe mocks, so we'll use
+      // the generic MockSyntheticEvent.
+      //
+      // *See other test with similar note to this one.*
       test('checks types correctly for Mock objects with `type` mocked', () {
-        final mockEvent = MockSyntheticMouseEvent();
+        final mockEvent = MockSyntheticEvent();
         when(mockEvent.type).thenReturn('click');
         expect(mockEvent.isMouseEvent, isTrue);
         expect(mockEvent.isKeyboardEvent, false);


### PR DESCRIPTION
## Motivation
When testing these changes, we ran into a case where a consumer was mocking `type`, and relying on type-checking utilities to respect that.
```dart
class MockSyntheticEvent extends Mock implements SyntheticEvent {}
```
```dart
final mockEvent = MockSyntheticEvent();
when(mockEvent.type).then('click');
print(mockEvent.isMouseEvent);
```

Previously, this would print `true`, but in v7_wip, it prints `false`.

## Solution
- Update event type checking to match old behavior.
- Add regression test and additional test

## Testing
- Verify that regression test fails in the commit before the fix was introduced
    - CI link: https://github.com/Workiva/react-dart/actions/runs/6817966382/job/18542598172
    - Expected failing test: `Synthetic event helpers SyntheticEventTypeHelpers checks types correctly for Mock objects with `type` mocked`
- Verify that regression test pass after the fix was introduced (latest CI passes)