### PR TITLE
[NO MERGE] MouseEvent.dataTransfer null exception - test failure example

### DIFF
--- a/test/react_client/event_helpers_test.dart
+++ b/test/react_client/event_helpers_test.dart
@@ -2105,6 +2105,14 @@ main() {
       });
     });
   });
+
+  // See: `SafeNativeDataTransfer` extension
+  group('SafeNativeDataTransfer MouseEvent extension', () {
+    test('prevents faulty Dart SDK web platform null exceptions when '
+        'accessing the `dataTransfer` getter on a manually constructed MouseEvent', () {
+      expect(() => wrapNativeMouseEvent(MouseEvent('click')).dataTransfer, returnsNormally);
+    });
+  });
 }
 
 enum SyntheticEventType {


### PR DESCRIPTION
This contains the test for a new extension that will be implemented in another PR, showing that the test is valid - causing the exception that the new extension will remedy.