### PR TITLE
FED-2812 Catch MouseEvent.dataTransfer null exception

### DIFF
--- a/lib/src/react_client/event_helpers.dart
+++ b/lib/src/react_client/event_helpers.dart
@@ -838,7 +838,7 @@ extension SafeNativeDataTransfer on MouseEvent {
   /// Unexpected null value encountered in Dart web platform libraries.
   /// ```
   ///
-  /// This extension is used will catch the error within our [wrapNativeMouseEvent] function so that
+  /// This extension is used to catch the error within our [wrapNativeMouseEvent] function so that
   /// `SyntheticMouseEvent`s do not throw the null exception.
   @internal
   DataTransfer? get safeDataTransfer {

--- a/test/react_client/event_helpers_test.dart
+++ b/test/react_client/event_helpers_test.dart
@@ -2108,7 +2108,8 @@ main() {
 
   // See: `SafeNativeDataTransfer` extension
   group('SafeNativeDataTransfer MouseEvent extension', () {
-    test('prevents faulty Dart SDK web platform null exceptions when '
+    test(
+        'prevents faulty Dart SDK web platform null exceptions when '
         'accessing the `dataTransfer` getter on a manually constructed MouseEvent', () {
       expect(() => wrapNativeMouseEvent(MouseEvent('click')).dataTransfer, returnsNormally);
     });

--- a/test/react_client/event_helpers_test.dart
+++ b/test/react_client/event_helpers_test.dart
@@ -2105,6 +2105,14 @@ main() {
       });
     });
   });
+
+  // See: `SafeNativeDataTransfer` extension
+  group('SafeNativeDataTransfer MouseEvent extension', () {
+    test('prevents faulty Dart SDK web platform null exceptions when '
+        'accessing the `dataTransfer` getter on a manually constructed MouseEvent', () {
+      expect(() => wrapNativeMouseEvent(MouseEvent('click')).dataTransfer, returnsNormally);
+    });
+  });
 }
 
 enum SyntheticEventType {


### PR DESCRIPTION
### The Problem

In Dart SDK versions with null-safety enabled, [the interop](https://github.com/dart-lang/sdk/blob/master/sdk/lib/html/dart2js/html_dart2js.dart#L22421-L22422) for `MouseEvent.dataTransfer` is non-nullable despite the [JS spec for `dataTransfer`](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/dataTransfer) clearly indicating that it can be null.

This can cause the SDK to throw when a `MouseEvent` is manually constructed _(e.g. [in a test utility](https://github.com/workiva/over_react_test/blob/dd90164b94e18faac363ced0dc0508ca780183b0/lib/src/over_react_test/dom_util.dart#L63-L69))_, and the `dataTransfer` getter is then accessed when running with `sound_null_safety` enabled:

```
Unexpected null value encountered in Dart web platform libraries.
```

> [More info about these native non-null assertions can be found here if you're really curious](https://github.com/dart-lang/sdk/blob/master/sdk/lib/html/doc/NATIVE_NULL_ASSERTIONS.md)

### The Solution

While we cannot fix the native `MouseEvent.dataTransfer` issue directly, we _can_ monkey patch this flawed non-null assertion for the `SyntheticMouseEvent.dataTransfer` property that all of our consumer's UI / tests will be accessing as they migrate to null safety.

This PR adds an extension method that catches the Dart SDK's exception in a new `safeDataTransfer` getter, and updates the `wrapNativeMouseEvent` implementation to make `SyntheticMouseEvent.dataTransfer` access the new `safeDataTransfer` getter instead of the native `MouseEvent.dataTransfer` directly.

### QA

1. [ ] Verify that the test added in this PR fails without the new extension method (See failing tests here:  https://github.com/Workiva/react-dart/pull/397)
1. [ ] Verify that the same test is passing in this PR.