### PR TITLE
Add CDN publish back temporarily

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         # Can't run on `stable` (Dart 3) until we're fully null-safe.
-        sdk: [2.18.7, 2.19.6]
+        sdk: [2.19.6]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
@@ -36,7 +36,7 @@ jobs:
 
       - name: Verify formatting
         run: dart run dart_dev format --check
-        if: ${{ matrix.sdk == '2.18.7' }}
+        if: ${{ matrix.sdk == '2.19.6' }}
 
       - name: Analyze project source
         run: dart analyze
@@ -44,21 +44,13 @@ jobs:
 
       - name: Run tests (DDC)
         run: |
-          if [ ${{ matrix.sdk }} = '2.13.4' ]; then 
-            dart run build_runner test --delete-conflicting-outputs -- --preset dartdevc-legacy
-          else 
-            dart run build_runner test --delete-conflicting-outputs -- --preset dartdevc
-          fi
+          dart run build_runner test --delete-conflicting-outputs -- --preset dartdevc
         if: always() && steps.install.outcome == 'success'
         timeout-minutes: 5
 
       - name: Run tests (dart2js)
         run: |
-          if [ ${{ matrix.sdk }} = '2.13.4' ]; then
-            dart run build_runner test --delete-conflicting-outputs --release -- --preset dart2js-legacy
-          else 
-            dart run build_runner test --delete-conflicting-outputs --release -- --preset dart2js
-          fi
+          dart run build_runner test --delete-conflicting-outputs --release -- --preset dart2js
         if: always() && steps.install.outcome == 'success'
         timeout-minutes: 5
       - uses: anchore/sbom-action@v0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:2 as dart2
+
+RUN dart --version
+
+WORKDIR /build
+COPY pubspec.yaml .
+
+RUN dart pub get
+
+COPY /lib ./lib/
+RUN cd lib && tar -czvf ../cdn_assets.tar.gz *.js *.map
+ARG BUILD_ARTIFACTS_CDN=/build/cdn_assets.tar.gz
+
+FROM scratch

--- a/example/test/react_test_components.dart
+++ b/example/test/react_test_components.dart
@@ -129,7 +129,8 @@ class _ClockComponent extends react.Component {
 
   @override
   render() {
-    return react.span({'onClick': (event) => print('Hello World!')},
+    return react.span(
+        {'onClick': (event) => print('Hello World!')},
 //        { 'onClick': (event, [domid = null]) => print("Hello World!") },
         ['Seconds elapsed: ', "${state['secondsElapsed']}"]);
   }

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,0 +1,36 @@
+name: validate_cdn_artifact
+description: Verifies the cdn artifact generated in the build contains the JS bundle files
+image: drydock.workiva.net/workiva/skynet-images:node-test-image-latest
+size: large
+timeout: 900
+
+requires:
+  Workiva/react-dart:
+    - cdn
+
+scripts:
+  - mkdir build
+  - cp $SKYNET_APPLICATION_REACT_DART_CDN ./build
+  - cd build
+  - tar -xf cdn_assets.tar.gz
+  - test -e ./react.js && { echo 'Verified dev bundle exists in CDN artifact.'; } || { echo 'Dev bundle /lib/react.js should exist in CDN artifact.'; exit 1; }
+  - test -e ./react_dom.js && { echo 'Verified dev DOM bundle exists in CDN artifact.'; } || { echo 'Dev DOM bundle /lib/react_dom.js should exist in CDN artifact.'; exit 1; }
+  - test -e ./react_with_react_dom_prod.js && { echo 'Verified prod bundle exists in CDN artifact.'; } || { echo 'Prod bundle /lib/react_with_react_dom_prod.js should exist in CDN artifact.'; exit 1; }
+  - test -e ./react_prod.js && { echo 'Verified prod bundle exists in CDN artifact.'; } || { echo 'Prod bundle /lib/react_prod.js should exist in CDN artifact.'; exit 1; }
+  - test -e ./react_dom_prod.js && { echo 'Verified prod DOM bundle exists in CDN artifact.'; } || { echo 'Prod DOM bundle /lib/react_dom_prod.js should exist in CDN artifact.'; exit 1; }
+
+---
+
+name: verify-github-actions
+description: Verify that the github actions run passed, this is needed to make pipelines pass without manual intervention
+contact: 'Frontend Frameworks Architecture / #support-frontend-architecture'
+image: drydock.workiva.net/workiva/skynet-images:3728345 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
+size: small
+timeout: 600
+
+env:
+# encrypted github token used for requests to api.github.com
+ - secure: wqV2dUVmOMNZgll+/Sr4fra76p+gTvqRS3QvNQASg3hzoysFz7enBaKsXKXoPFj+jexOvFVN/m4rko272z/xZ6lBMRI=
+
+scripts:
+  - python3 /actions/verify_github_actions.py


### PR DESCRIPTION
# Summary

We moved to Github Actions but need to fix some things internal to Workiva before being able to remove Dockerfile and skynet.yaml completely. This undoes those removals and drops older versions of Dart from CI. 
