### PR TITLE
RM-270006 Release react-dart 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.2.0
+- Add Dart wrapper for React [lazy](https://react.dev/reference/react/lazy)
+
 ## 7.1.3
 - Internal release tooling changes
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 7.1.3
+version: 7.2.0
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [FED-3207 Add react lazy](https://github.com/Workiva/react-dart/pull/406)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/react-dart/compare/7.1.3...Workiva:release_react-dart_7.2.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/react-dart/compare/7.1.3...7.2.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4743698779471872/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4743698779471872/?repo_name=Workiva%2Freact-dart&pull_number=408)