### PR TITLE
FED-3253 Officially support Dart 3

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [2.19.6, 3.4.4, stable]
+        sdk: [2.19.6, 3.2.6, 3.4.4, stable]
     steps:
       - uses: actions/checkout@v2
       - id: setup-dart

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -10,6 +10,23 @@ on:
       - '**'
 
 jobs:
+  # Run as a separate job outside the Dart SDK matrix below,
+  # since we can only emit a single SBOM.
+  create-sbom-release-asset:
+    name: Create SBOM Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: dart-lang/setup-dart@v1
+        with:
+          sdk: 2.19.6 # This version doesn't matter so long as it resolves.
+      - run: dart pub get
+      - name: Publish SBOM to Release Assets
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./
+          format: cyclonedx-json
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -60,7 +77,3 @@ jobs:
           dart run build_runner test --delete-conflicting-outputs --release -- --preset dart2js
         if: always() && steps.install.outcome == 'success'
         timeout-minutes: 8
-      - uses: anchore/sbom-action@v0
-        with:
-          path: ./
-          format: cyclonedx-json

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,16 +15,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Can't run on `stable` (Dart 3) until we're fully null-safe.
-        sdk: [2.19.6]
+        sdk: [2.19.6, 3.4.4, main]
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
+      - id: setup-dart
+        uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ matrix.sdk }}
 
       - name: Print Dart SDK version
         run: dart --version
+
+      - name: Delete Dart-2-only files when running on Dart 3
+        run: |
+          DART_VERSION="${{ steps.setup-dart.outputs.dart-version }}"
+          if [[ "$DART_VERSION" =~ ^3 ]]; then
+            ./tool/delete_dart_2_only_files.sh
+          fi
 
       - id: install
         name: Install dependencies

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [2.19.6, 3.4.4, main]
+        sdk: [2.19.6, 3.4.4, stable]
     steps:
       - uses: actions/checkout@v2
       - id: setup-dart

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: dart-lang/setup-dart@v1
+      - uses: dart-lang/setup-dart@v1
         with:
           sdk: 2.19.6 # This version doesn't matter so long as it resolves.
       - run: dart pub get

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -53,13 +53,13 @@ jobs:
         run: |
           dart run build_runner test --delete-conflicting-outputs -- --preset dartdevc
         if: always() && steps.install.outcome == 'success'
-        timeout-minutes: 5
+        timeout-minutes: 8
 
       - name: Run tests (dart2js)
         run: |
           dart run build_runner test --delete-conflicting-outputs --release -- --preset dart2js
         if: always() && steps.install.outcome == 'success'
-        timeout-minutes: 5
+        timeout-minutes: 8
       - uses: anchore/sbom-action@v0
         with:
           path: ./

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [2.19.6, 3.2.6, 3.4.4, stable]
+        sdk: [2.19.6, stable]
     steps:
       - uses: actions/checkout@v2
       - id: setup-dart

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -4,6 +4,9 @@ platforms:
   - chrome
   - vm
 
+# Work around process handing after tests finish: https://github.com/dart-lang/build/issues/3765
+concurrency: 1
+
 presets:
   dart2js-legacy:
     exclude_tags: no-dart2js

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ version: 7.2.0
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.13.0 <4.0.0'
 dependencies:
   js: ^0.6.3
   meta: ^1.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dev_dependencies:
   args: ^2.0.0
   build_runner: ^2.1.2
   build_test: ^2.1.3
-  build_web_compilers: ^3.0.0
+  build_web_compilers: ">=3.0.0 <5.0.0"
   dart_dev: ^4.0.0
   dependency_validator: ^3.2.2
   glob: ^2.0.0

--- a/tool/delete_dart_2_only_files.sh
+++ b/tool/delete_dart_2_only_files.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+#
+# This script deletes files that can only be run in Dart 2 (ones not using null-safety),
+# and need to be deleted for analysis and compilation to work in Dart 3.
+#
+
+set -e
+
+rm test/nullable_callback_detection/non_null_safe_refs.dart
+rm test/nullable_callback_detection/nullable_callback_detection_unsound_test.dart


### PR DESCRIPTION
Related over_react PR: https://github.com/Workiva/over_react/pull/958

## Motivation

We should support Dart 3.

react-dart can currently be consumed in Dart 3, despite not supporting it in its SDK constraints, due to the way [Dart 3 treats null-safe packages as compatible](https://dart.dev/resources/dart-3-migration#dart-3-backwards-compatibility). 

However, we don't officially support Dart 3, and our automated CI checks don't validate that it works properly in Dart 3.

Also, we still need to support Dart 2 for the time being, so ideally we'd be able to support both Dart 2 and 3 in the same react-dart version, and run CI against each Dart version.

## Changes
- Raise SDK constraints to explicitly support Dart 3
- Update CI to run against both Dart 2 and Dart 3
    - In Dart 3 runs, delete non-null-safe browser test cases, since they don't apply in Dart 3 and won't compile
    - Work around test hanging issue in Dart 3
    - Break SBOM job out of matrix, since it can only get run once
- dev_dependencies: widen build_web_compilers to allow versions needed by Dart 3


> [!CAUTION]
> There's a bug in Dart >=3.3.0 <3.5.0 that breaks the behavior in DDC of certain functions passed to components, such as refs and potentially JS callback props: https://github.com/dart-lang/sdk/issues/56897
>
> We can't prevent users on those versions from pulling in react-dart, since they can already resolve to [null-safe versions](https://dart.dev/resources/dart-3-migration#dart-3-backwards-compatibility) that have already been published.
>
> So, consumers will just have to avoid those versions of Dart, or use dart2js during development or tests. 
>
> If needed, we could potentially follow up with a warning that detects this bug and provides a helpful error.

### QA Checklist
- CI runs in both Dart 2 and 3, and all steps pass
