### PR TITLE
RM-288881 Release react-dart 7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 7.3.0
+- Add new, opt-in React 18 JS files (see [README](https://github.com/Workiva/react-dart#html) for more info)
+   - The preexisting JS files that use React 17 are now deprecated, and will be removed in the next major version, 8.0.0.
+- Raise SDK constraint from `<3.0.0` to `<4.0.0`, run CI on Dart 3
+
 ## 7.2.0
 - Add Dart wrapper for React [lazy](https://react.dev/reference/react/lazy)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ In a `.html` file, include the javascript libraries
 _(provided with this library for compatibility reasons)_ within your `.html` file,
 and also add an element with an `id` to mount your React component.
 
-This library is in the process of migrating to React 18, but while this is happening it will continue to support both React 17 and React 18. The React 17 js files are deprecated but available to ease migration and will be removed at some point in a future major version.
+This package now supports both React 17 and React 18. To opt into React 18, replace usages of this package's JS files with their new, React 18 versions (see table below).
+
+The React 17 JS files are now deprecated, and will be removed in the next major version of this package, 8.0.0.
 
 ##### React 18
 | Mode        | Library          | JS File Name                                |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 7.2.0
+version: 7.3.0
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [FED-3283: React 18 js files](https://github.com/Workiva/react-dart/pull/414)
* Patch changes:
	* [FED-3253 Officially support Dart 3](https://github.com/Workiva/react-dart/pull/409)
	* [Raise the build_web_compilers dependency max to v5.0.0](https://github.com/Workiva/react-dart/pull/410)
	* [Raise the meta dependency min to v1.16.0](https://github.com/Workiva/react-dart/pull/411)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/react-dart/compare/7.2.0...Workiva:release_react-dart_7.3.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/react-dart/compare/7.2.0...7.3.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4743698779471872/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4743698779471872/?repo_name=Workiva%2Freact-dart&pull_number=415)