### PR TITLE
no_entrypoint_imports

### DIFF
--- a/lib/src/react_client/chain_refs.dart
+++ b/lib/src/react_client/chain_refs.dart
@@ -1,5 +1,5 @@
 import 'package:js/js_util.dart';
-import 'package:react/react.dart' as react;
+
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/src/react_client/factory_util.dart';
 

--- a/lib/src/react_client/component_registration.dart
+++ b/lib/src/react_client/component_registration.dart
@@ -1,6 +1,6 @@
 import 'dart:html';
 
-import 'package:react/react.dart';
+
 import 'package:react/react_client/bridge.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/react_interop.dart';

--- a/lib/src/react_client/dart_interop_statics.dart
+++ b/lib/src/react_client/dart_interop_statics.dart
@@ -6,7 +6,7 @@ import 'dart:js_util';
 
 import 'package:js/js.dart';
 import 'package:meta/meta.dart';
-import 'package:react/react.dart';
+
 import 'package:react/react_client/bridge.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/js_interop_helpers.dart';

--- a/lib/src/react_client/internal_react_interop.dart
+++ b/lib/src/react_client/internal_react_interop.dart
@@ -6,7 +6,7 @@ library react.src.react_client.internal_react_interop;
 
 import 'package:js/js.dart';
 import 'package:meta/meta.dart';
-import 'package:react/react.dart' show Component, Component2, ComponentFactory;
+
 import 'package:react/react_client/bridge.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/react_interop.dart'

--- a/lib/src/react_client/lazy.dart
+++ b/lib/src/react_client/lazy.dart
@@ -1,7 +1,7 @@
 import 'dart:js';
 import 'dart:js_util';
 
-import 'package:react/react.dart';
+
 import 'package:react/react_client/component_factory.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/src/js_interop_util.dart';
@@ -14,7 +14,7 @@ import 'package:react/src/js_interop_util.dart';
 ///
 /// Example usage:
 /// ```dart
-/// import 'package:react/react.dart' show lazy, Suspense;
+/// 
 /// import './simple_component.dart' deferred as simple;
 ///
 /// final lazyComponent = lazy(() async {

--- a/lib/src/react_client/private_utils.dart
+++ b/lib/src/react_client/private_utils.dart
@@ -4,7 +4,7 @@ library react_client_private_utils;
 import 'dart:js_util';
 
 import 'package:js/js.dart';
-import 'package:react/react.dart' show Component2;
+
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/src/js_interop_util.dart';
 import 'package:react/src/react_client/component_registration.dart' show registerComponent2;

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -1,6 +1,6 @@
 library react.typedefs;
 
-import 'package:react/react.dart';
+
 import 'package:react/react_client/js_backed_map.dart';
 
 /// The type of `Component.ref` specified as a callback.


### PR DESCRIPTION
## Problem

An entrypoint import can be defined as an import within `lib/src` that imports a file within `lib/*.dart` (the entrypoints of a dart package). These imports are always unnecessary, and can contribute to slower dart build performance.

## Solution

This PR naively removes every entrypoint import within the repo, and updates the `gha-dart/.../checks.yaml` to the latest version. In order to merge this PR a few manual changes must be performed:

- Navigate to every file which has analysis errors caused from the missing import. Rely on intellisense to import the necessary symbol from the specific file, not the entrypoint import
- Implement the `no_entrypoint_imports` additional-checks option in `gha-dart@v2.10.13` that was added in [this PR](https://github.com/Workiva/gha-dart/pull/716). This will prevent new entrypoint imports from getting added once this PR merges

Our request to teams is to perform the above tasks, so we can default enable the `no_entrypoint_imports` check for all gha-dart consumers. Please reach out to [#support-frontend-dx](https://workiva.enterprise.slack.com/archives/C03ESR91BNU) for any questions or issues

## QA

- [ ] This pr is heavily dependant on the analysis server, and as such CI passes should be sufficient

[_Created by Sourcegraph batch change `Workiva/no_entrypoint_imports`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/no_entrypoint_imports)